### PR TITLE
Builder constructor must be public

### DIFF
--- a/src/main/java/io/honeycomb/opentelemetry/HoneycombSdk.java
+++ b/src/main/java/io/honeycomb/opentelemetry/HoneycombSdk.java
@@ -48,7 +48,7 @@ public final class HoneycombSdk implements OpenTelemetry {
     }
 
     public static class Builder {
-        Builder() {}
+        public Builder() {}
 
         private final String HONEYCOMB_TEAM_HEADER = "X-Honeycomb-Team";
         private final String HONEYCOMB_DATASET_HEADER = "X-Honeycomb-Dataset";


### PR DESCRIPTION
In order to be accessed from outside the package, the builder constructor has to be public. 