### PR TITLE
set service name and distro metadata via SPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,31 @@ Baggage.current()
     .makeCurrent();
 ```
 
+### Resource Attributes
+
+Sometimes you'll want one or more attributes set on all spans within a service.
+
+Using environment variables:
+
+```sh
+OTEL_RESOURCE_ATTRIBUTES=ec2.instanceid=i-1234567890abcdef0,build_id=1337 \
+SERVICE_NAME=my-favorite-service \
+HONEYCOMB_API_KEY=my-api-key \
+HONEYCOMB_DATASET=my-dataset \
+java -javaagent:honeycomb-opentelemetry-javaagent-0.1.0-all.jar -jar myapp.jar
+```
+
+Using system properties:
+
+```sh
+java \
+-Dotel.resource.attributes=ec2.instanceid=i-1234567890abcdef0,build_id=1337 \
+-Dservice.name=my-favorite-service \
+-Dhoneycomb.api.key=my-api-key \
+-Dhoneycomb.dataset=my-dataset \
+-javaagent:honeycomb-opentelemetry-javaagent-0.1.0-all.jar -jar myapp.jar
+```
+
 ## SDK Usage
 
 For teams that opt not to use the agent for auto-instrumentation, the Honeycomb OpenTelemetry SDK provides convenient setup for sending manual OpenTelemetry instrumentation to Honeycomb. The SDK also provides a deterministic sampler and more span processing options.

--- a/agent/src/main/java/io/honeycomb/opentelemetry/HoneycombAgent.java
+++ b/agent/src/main/java/io/honeycomb/opentelemetry/HoneycombAgent.java
@@ -37,7 +37,6 @@ public class HoneycombAgent {
         final String apiKey = EnvironmentConfiguration.getHoneycombApiKey();
         final String apiEndpoint = EnvironmentConfiguration.getHoneycombApiEndpoint();
         final String dataset = EnvironmentConfiguration.getHoneycombDataset();
-        final String serviceName = EnvironmentConfiguration.getServiceName();
 
         if (apiKey == null) {
             throw new Exception("WARN: Could not start Honeycomb agent: "
@@ -51,10 +50,6 @@ public class HoneycombAgent {
         System.setProperty("otel.exporter.otlp.headers",
             String.format("x-honeycomb-team=%s,x-honeycomb-dataset=%s", apiKey, dataset));
         System.setProperty("otel.exporter.otlp.endpoint", apiEndpoint);
-        if (serviceName != null) {
-            System.setProperty("otel.resource.attributes",
-                String.format("service.name=%s", serviceName));
-        }
     }
 
 }

--- a/custom/src/main/java/io/honeycomb/opentelemetry/DistroMetadataResourceProvider.java
+++ b/custom/src/main/java/io/honeycomb/opentelemetry/DistroMetadataResourceProvider.java
@@ -1,0 +1,17 @@
+package io.honeycomb.opentelemetry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+import org.apache.commons.lang3.StringUtils;
+
+public class DistroMetadataResourceProvider implements ResourceProvider {
+    @Override
+    public Resource createResource(ConfigProperties config) {
+        AttributesBuilder attributesBuilder = Attributes.builder();
+        DistroMetadata.getMetadata().forEach(attributesBuilder::put);
+        return Resource.create(attributesBuilder.build());
+    }
+}

--- a/custom/src/main/java/io/honeycomb/opentelemetry/DistroMetadataResourceProvider.java
+++ b/custom/src/main/java/io/honeycomb/opentelemetry/DistroMetadataResourceProvider.java
@@ -5,7 +5,6 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
-import org.apache.commons.lang3.StringUtils;
 
 public class DistroMetadataResourceProvider implements ResourceProvider {
     @Override

--- a/custom/src/main/java/io/honeycomb/opentelemetry/HoneycombSdkTracerProviderConfigurer.java
+++ b/custom/src/main/java/io/honeycomb/opentelemetry/HoneycombSdkTracerProviderConfigurer.java
@@ -25,15 +25,6 @@ public class HoneycombSdkTracerProviderConfigurer implements SdkTracerProviderCo
             sampleRate = 1;
         }
 
-        AttributesBuilder attributesBuilder = Attributes.builder();
-        DistroMetadata.getMetadata().forEach(attributesBuilder::put);
-        String serviceName = EnvironmentConfiguration.getServiceName();
-        if (StringUtils.isNotEmpty(serviceName)) {
-            attributesBuilder.put(EnvironmentConfiguration.SERVICE_NAME_FIELD, serviceName);
-        }
-        tracerProvider.setResource(
-            Resource.create(attributesBuilder.build()));
-
         tracerProvider
             .setSampler(new DeterministicTraceSampler(sampleRate))
             .addSpanProcessor(new BaggageSpanProcessor());

--- a/custom/src/main/java/io/honeycomb/opentelemetry/ServiceNameResourceProvider.java
+++ b/custom/src/main/java/io/honeycomb/opentelemetry/ServiceNameResourceProvider.java
@@ -1,0 +1,21 @@
+package io.honeycomb.opentelemetry;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+import org.apache.commons.lang3.StringUtils;
+
+public class ServiceNameResourceProvider implements ResourceProvider {
+    private static final AttributeKey<String> SERVICE_NAME_FIELD =
+        AttributeKey.stringKey(EnvironmentConfiguration.SERVICE_NAME_FIELD);
+
+    @Override
+    public Resource createResource(ConfigProperties config) {
+        String serviceName = EnvironmentConfiguration.getServiceName();
+        return StringUtils.isNotEmpty(serviceName)
+            ? Resource.create(Attributes.of(SERVICE_NAME_FIELD, serviceName))
+            : Resource.empty();
+    }
+}

--- a/custom/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/custom/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,0 +1,2 @@
+io.honeycomb.opentelemetry.ServiceNameResourceProvider
+io.honeycomb.opentelemetry.DistroMetadataResourceProvider


### PR DESCRIPTION
Fixes #40

Previously, we were clobbering any resource attributes set via environment variable (`OTEL_RESOURCE_ATTRIBUTES`) or properties (`otel.resource.attributes`). This change uses the OTel Java autoconfiguration SPI to set the service name and distro metadata fields via a ResourceProvider ([example](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/0c7a20d3fdcfcfa605fe997d669dd3608c79408f/examples/distro/custom/src/main/java/com/example/javaagent/DemoResourceProvider.java)). This is akin to the pattern for configuring the trace provider via an `SdkTracerProviderConfigurer` that we're already using to customize tracing.

We're keeping the clobber of `otel.exporter.otlp.(headers|endpoint)` properties in `HoneycombAgent.configure()` because those properties shouldn't be set to anything else when sending to Honeycomb with the Honeycomb Agent.