### PR TITLE
Add maven publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,7 @@ jobs:
           steps:
             - run:
                 name: "Publish Artifacts to Maven"
-                command: |
-                  GPG_BASE64=$GPG_BASE64 GPG_PASSWORD=$GPG_PASSWORD \
-                  OSSRH_USERNAME=$OSSRH_USERNAME OSSRH_PASSWORD=$OSSRH_PASSWORD \
-                  ./gradlew publish
+                command: ./gradlew publish
 
 filters_always: &filters_always
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,4 +95,7 @@ workflows:
           context: java_beeline
           requires:
             - build
-          <<: *filters_publish
+          filters:
+            branches:
+              only:
+                - vera.maven-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,4 @@ workflows:
           context: java_beeline
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - vera.maven-publish
+          <<: *filters_publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,14 @@ jobs:
       - checkout
       - gradle/with_cache:
           steps:
-            - run: ./gradlew publish
+            - run:
+                name: "Publish Artifacts to Maven"
+                command: ./gradlew publish
+                environment:
+                  GPG_BASE64: $GPG_BASE64
+                  GPG_PASSWORD: $GPG_PASSWORD
+                  OSSRH_USERNAME: $OSSRH_USERNAME
+                  OSSRH_PASSWORD: $OSSRH_PASSWORD
 
 filters_always: &filters_always
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,10 @@ jobs:
           steps:
             - run:
                 name: "Publish Artifacts to Maven"
-                command: ./gradlew publish
-                environment:
-                  GPG_BASE64: $GPG_BASE64
-                  GPG_PASSWORD: $GPG_PASSWORD
-                  OSSRH_USERNAME: $OSSRH_USERNAME
-                  OSSRH_PASSWORD: $OSSRH_PASSWORD
+                command: |
+                  GPG_BASE64=$GPG_BASE64 GPG_PASSWORD=$GPG_PASSWORD \
+                  OSSRH_USERNAME=$OSSRH_USERNAME OSSRH_PASSWORD=$OSSRH_PASSWORD \
+                  ./gradlew publish
 
 filters_always: &filters_always
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           steps:
             - run: mkdir -p ~/artifacts
             - run: ./gradlew build -x test
-            - run: cp agent/build/libs/*all.jar ~/artifacts
+            - run: cp **/build/libs/*.jar ~/artifacts
             - persist_to_workspace:
                 root: ~/
                 paths:
@@ -32,6 +32,14 @@ jobs:
             echo "about to publish to tag ${CIRCLE_TAG}"
             ls -l ~/artifacts/*
             ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+
+  publish_maven:
+    executor: gradle/default
+    steps:
+      - checkout
+      - gradle/with_cache:
+          steps:
+            - run: ./gradlew publish
 
 filters_always: &filters_always
   filters:
@@ -80,6 +88,11 @@ workflows:
           <<: *filters_always
       - publish_github:
           context: Honeycomb Secrets for Public Repos
+          requires:
+            - build
+          <<: *filters_publish
+      - publish_maven:
+          context: java_beeline
           requires:
             - build
           <<: *filters_publish

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,11 @@
+# Creating a new release
+
+1. First, update the `project.version` in the root build.gradle file. Also update the Changelog, as well as any references to the previous version in the docs.
+
+1. Once the above changes are merged into `main`, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off CI, which will publish a draft GitHub release, and stage the new release in [Sonatype](https://oss.sonatype.org).
+
+1. You should now see the new release in Sonatype UI under `Staging Repositories`. Select the release, and "Close" it. That will do some validation. Once that's done, you should be able to "Release" it to make it available in Maven. See more details in [Sonatype docs](https://help.sonatype.com/repomanager2/staging-releases/managing-staging-repositories).
+
+1. Update Release Notes on the new draft GitHub release, and publish that.
+
+Voila!

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -61,12 +61,3 @@ tasks {
         dependsOn(shadowJar)
     }
 }
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            artifactId = "${artifactName}"
-            from components.java
-        }
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -103,8 +103,11 @@ subprojects {
         signing {
             def base64key = System.getenv("GPG_BASE64")
             def pw = System.getenv("GPG_PASSWORD")
+            def key = ""
 
-            def key = new String(Base64.getDecoder().decode(base64key)).trim()
+            if (base64key != null) {
+                key = new String(Base64.getDecoder().decode(base64key)).trim()
+            }
 
             useInMemoryPgpKeys(key, pw)
             sign publishing.publications.mavenJava

--- a/build.gradle
+++ b/build.gradle
@@ -42,4 +42,61 @@ subprojects {
             languageVersion.set(JavaLanguageVersion.of(8)) // compile it to ensure runtime compatibility with Java 8
         }
     }
+
+    plugins.withId("maven-publish") {
+        publishing {
+            publications {
+                mavenJava(MavenPublication) {
+                    from components.java
+                    artifactId = jar.archiveBaseName
+                    version = '0.1.0'
+                    versionMapping {
+                        usage('java-api') {
+                            fromResolutionOf('runtimeClasspath')
+                        }
+                        usage('java-runtime') {
+                            fromResolutionResult()
+                        }
+                    }
+                    pom {
+                        name = 'Honeycomb OpenTelemetry Exporters for Java'
+                        description = 'Exports OpenTelemetry data to Honeycomb.'
+                        url = 'https://docs.honeycomb.io/getting-data-in/open-standards/'
+                        licenses {
+                            license {
+                                name = 'The Apache License, Version 2.0'
+                                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            }
+                        }
+                        developers {
+                            developer {
+                                id = 'Honeycomb'
+                                name = 'Honeycomb'
+                                email = 'support@honeycomb.io'
+                                organization = 'Honeycomb'
+                                organizationUrl = 'https://honeycomb.io'
+                            }
+                        }
+                        scm {
+                            url = 'https://github.com/honeycombio/opentelemetry-java/tree/main/exporters'
+                            connection = 'scm:git:git@github.com:honeycombio/opentelemetry-java.git'
+                            developerConnection = 'scm:git:git@github.com:honeycombio/opentelemetry-java.git'
+                        }
+                    }
+                }
+            }
+            repositories {
+                maven {
+                    def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+                    def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
+                    url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                    if (project.hasProperty('sonatypeUsername'))
+                        credentials {
+                            username sonatypeUsername
+                            password sonatypePassword
+                        }
+                }
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,15 @@ subprojects {
     }
 
     plugins.withId("maven-publish") {
+        plugins.apply("signing")
+
         publishing {
             publications {
                 mavenJava(MavenPublication) {
                     from components.java
-                    artifactId = jar.archiveBaseName
+                    afterEvaluate {
+                        artifactId = project.findProperty("archivesBaseName") as String
+                    }
                     version = '0.1.0'
                     versionMapping {
                         usage('java-api') {
@@ -59,9 +63,8 @@ subprojects {
                         }
                     }
                     pom {
-                        name = 'Honeycomb OpenTelemetry Exporters for Java'
-                        description = 'Exports OpenTelemetry data to Honeycomb.'
-                        url = 'https://docs.honeycomb.io/getting-data-in/open-standards/'
+                        name = 'Honeycomb OpenTelemetry Distribution for Java'
+                        url = 'https://github.com/honeycombio/honeycomb-opentelemetry-java'
                         licenses {
                             license {
                                 name = 'The Apache License, Version 2.0'
@@ -78,9 +81,9 @@ subprojects {
                             }
                         }
                         scm {
-                            url = 'https://github.com/honeycombio/opentelemetry-java/tree/main/exporters'
-                            connection = 'scm:git:git@github.com:honeycombio/opentelemetry-java.git'
-                            developerConnection = 'scm:git:git@github.com:honeycombio/opentelemetry-java.git'
+                            url = 'https://github.com/honeycombio/honeycomb-opentelemetry-java'
+                            connection = 'scm:git:git@github.com:honeycombio/honeycomb-opentelemetry-java.git'
+                            developerConnection = 'scm:git:git@github.com:honeycombio/honeycomb-opentelemetry-java.git'
                         }
                     }
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ subprojects {
 
         signing {
             def base64key = System.getenv("GPG_BASE64")
-            def pw = System.getenv("GPG_PASSWORD")
+            def pw = System.getenv("GPG_PASSPHRASE")
             def key = ""
 
             if (base64key != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ subprojects {
                     afterEvaluate {
                         artifactId = project.findProperty("archivesBaseName") as String
                     }
-                    version = '0.1.0'
                     versionMapping {
                         usage('java-api') {
                             fromResolutionOf('runtimeClasspath')
@@ -102,7 +101,12 @@ subprojects {
         }
 
         signing {
-            useInMemoryPgpKeys(System.getenv("GPG_PRIVATE_KEY"), System.getenv("GPG_PASSWORD"))
+            def base64key = System.getenv("GPG_BASE64")
+            def pw = System.getenv("GPG_PASSWORD")
+
+            def key = new String(Base64.getDecoder().decode(base64key)).trim()
+
+            useInMemoryPgpKeys(key, pw)
             sign publishing.publications.mavenJava
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -93,13 +93,17 @@ subprojects {
                     def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
                     def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
                     url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-                    if (project.hasProperty('sonatypeUsername'))
-                        credentials {
-                            username sonatypeUsername
-                            password sonatypePassword
-                        }
+                    credentials {
+                        username = System.getenv("OSSRH_USERNAME")
+                        password = System.getenv("OSSRH_PASSWORD")
+                    }
                 }
             }
+        }
+
+        signing {
+            useInMemoryPgpKeys(System.getenv("GPG_PRIVATE_KEY"), System.getenv("GPG_PASSWORD"))
+            sign publishing.publications.mavenJava
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ subprojects {
         toolchain {
             languageVersion.set(JavaLanguageVersion.of(8)) // compile it to ensure runtime compatibility with Java 8
         }
+        withJavadocJar()
+        withSourcesJar()
     }
 
     plugins.withId("maven-publish") {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java'
     id "maven-publish"
-
 }
 
 def artifactName = "honeycomb-opentelemetry-common"
@@ -9,4 +8,3 @@ def artifactName = "honeycomb-opentelemetry-common"
 jar {
     archivesBaseName = "${artifactName}"
 }
-

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,11 +10,3 @@ jar {
     archivesBaseName = "${artifactName}"
 }
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            artifactId = "${artifactName}"
-            from components.java
-        }
-    }
-}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -30,12 +30,3 @@ dependencies {
 jar {
     archivesBaseName = "${artifactName}"
 }
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            artifactId = "${artifactName}"
-            from components.java
-        }
-    }
-}

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/HoneycombSdk.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/HoneycombSdk.java
@@ -72,6 +72,7 @@ public final class HoneycombSdk implements OpenTelemetry {
          * the team making a request.</p>
          *
          * @param apiKey a String to use as the API key. See team settings in Honeycomb.
+         * @return builder
          */
         public Builder setApiKey(String apiKey) {
             this.apiKey = apiKey;
@@ -85,6 +86,7 @@ public final class HoneycombSdk implements OpenTelemetry {
          * the dataset that trace data is being written to.</p>
          *
          * @param dataset a String to use as the dataset name.
+         * @return builder
          */
         public Builder setDataset(String dataset) {
             this.dataset = dataset;
@@ -95,6 +97,7 @@ public final class HoneycombSdk implements OpenTelemetry {
          * Sets the Honeycomb endpoint to use. Optional, defaults to the Honeycomb ingest API.
          *
          * @param endpoint a String to use as the endpoint URI. Must begin with https or http.
+         * @return builder
          */
         public Builder setEndpoint(String endpoint) {
             this.endpoint = endpoint;
@@ -105,6 +108,7 @@ public final class HoneycombSdk implements OpenTelemetry {
          * Sets the service name as a resource attribute.
          *
          * @param serviceName a String to use as the service name
+         * @return builder
          */
         public Builder setServiceName(String serviceName) {
             this.serviceName = serviceName;
@@ -116,6 +120,9 @@ public final class HoneycombSdk implements OpenTelemetry {
          *
          * <p>Note that if none are specified, {@link W3CTraceContextPropagator} will be used
          * by default.</p>
+         *
+         * @param propagators {@link ContextPropagators} to use for context propagation
+         * @return builder
          */
         public Builder setPropagators(ContextPropagators propagators) {
             this.propagators = propagators;
@@ -125,10 +132,11 @@ public final class HoneycombSdk implements OpenTelemetry {
         /**
          * Sets the {@link Sampler} to use.
          *
-         * <p>Note that if no sampler is specified, AlwaysOnSampler</p>
+         * <p>Note that if no sampler is specified, AlwaysOnSampler
          * will be used by default.</p>
          *
-         * @param sampler Sampler instance
+         * @param sampler Sampler instance`
+         * @return builder
          */
         public Builder setSampler(Sampler sampler) {
             this.sampler = sampler;
@@ -141,6 +149,7 @@ public final class HoneycombSdk implements OpenTelemetry {
          * Enables multi-span attributes via a BaggageSpanProcessor
          *
          * @param spanProcessor Instance of a BaggageSpanProcessor or custom SpanProcessor
+         * @return builder
          */
         public Builder addSpanProcessor(SpanProcessor spanProcessor) {
             this.spanProcessor = spanProcessor;
@@ -155,6 +164,7 @@ public final class HoneycombSdk implements OpenTelemetry {
          * use as the global instance. If you need to configure multiple SDKs for tests, use {@link
          * GlobalOpenTelemetry#resetForTest()} between them.
          *
+         * @return {@link HoneycombSdk} instance
          * @see GlobalOpenTelemetry
          */
         public HoneycombSdk buildAndRegisterGlobal() {
@@ -174,6 +184,7 @@ public final class HoneycombSdk implements OpenTelemetry {
          * {@link SdkTracerProvider} with a {@link BatchSpanProcessor} that has an
          * {@link OtlpGrpcSpanExporter} configured.</p>
          *
+         * @return {@link HoneycombSdk} instance
          * @see GlobalOpenTelemetry
          */
         public HoneycombSdk build() {
@@ -220,7 +231,7 @@ public final class HoneycombSdk implements OpenTelemetry {
      *
      * <p>Static global providers are obfuscated when they are returned from the API to prevent users
      * from casting them to their SDK specific implementation. For example, we do not want users to
-     * use patterns like {@code (TracerSdkProvider) OpenTelemetry.getGlobalTracerProvider()}.
+     * use patterns like {@code (TracerSdkProvider) OpenTelemetry.getGlobalTracerProvider()}.</p>
      */
     @ThreadSafe
     @VisibleForTesting


### PR DESCRIPTION
Fixes #20 

got inspiration here: https://github.com/honeycombio/opentelemetry-java-exporter/blob/main/exporters/build.gradle and a myriad other places 🔮 

we have multi-module setup, so in order not to copy-pasta all the publishing setup, I put it in a conditional block in the parent gradle file

* adds publish step to CI
* copy all built jars to GitHub, not just the agent jar
* fix javadoc errors

Tested publishing to local Maven. Also tested publishing to snapshot repo in sonatype, and pulled that down in a local test app. Tested CI publish step as far as uploading the release to "staging" in sonatype.

The real test will be tagging a release when we're ready. This is still not fully automated yet, we will need to manually push the "release" button in sonatype. I figured we can automate that bit once we're happy that everything works so far.