### PR TITLE
Create methods for adding arbitrary resource attributes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,7 @@ HoneycombSdk honeycomb = new HoneycombSdk.Builder()
     .addSpanProcessor(new BaggageSpanProcessor()) // optional, for multi-span attributes
     .setEndpoint(YOUR_ENDPOINT) // optional, defaults to api.honeycomb.io
     .setServiceName(YOUR_SERVICE_NAME)
+    .addResourceAttribute("java.version", System.getProperty("java.version")) // optional
     .build();
 ```
 

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/HoneycombSdk.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/HoneycombSdk.java
@@ -59,6 +59,7 @@ public final class HoneycombSdk implements OpenTelemetry {
         private ContextPropagators propagators;
         private Sampler sampler = Sampler.alwaysOn();
         private SpanProcessor spanProcessor;
+        private AttributesBuilder resourceAttributes = Attributes.builder();
 
         private String apiKey;
         private String dataset;
@@ -157,6 +158,51 @@ public final class HoneycombSdk implements OpenTelemetry {
         }
 
         /**
+         * Add a string attribute as a resource attribute.
+         *
+         * @return AttributesBuilder
+         */
+        public AttributesBuilder addResourceAttribute(String key, String value) {
+            return this.resourceAttributes.put(key, value);
+        }
+
+        /**
+         * Add a long attribute as a resource attribute.
+         *
+         * @return AttributesBuilder
+         */
+        public AttributesBuilder addResourceAttribute(String key, long value) {
+            return this.resourceAttributes.put(key, value);
+        }
+
+        /**
+         * Add a double attribute as a resource attribute.
+         *
+         * @return AttributesBuilder
+         */
+        public AttributesBuilder addResourceAttribute(String key, double value) {
+            return this.resourceAttributes.put(key, value);
+        }
+
+        /**
+         * Add a boolean attribute as a resource attribute.
+         *
+         * @return AttributesBuilder
+         */
+        public AttributesBuilder addResourceAttribute(String key, boolean value) {
+            return this.resourceAttributes.put(key, value);
+        }
+
+        /**
+         * Add a String array attribute as a resource attribute.
+         *
+         * @return AttributesBuilder
+         */
+        public AttributesBuilder addResourceAttribute(String key, String... value) {
+            return this.resourceAttributes.put(key, value);
+        }
+
+        /**
          * Returns a new {@link HoneycombSdk} built with the configuration of this {@link
          * Builder} and registers it as the global {@link
          * io.opentelemetry.api.OpenTelemetry}. An exception will be thrown if this method is attempted to
@@ -210,13 +256,12 @@ public final class HoneycombSdk implements OpenTelemetry {
                 .setSampler(sampler)
                 .addSpanProcessor(BatchSpanProcessor.builder(exporter).build());
 
-            AttributesBuilder attributesBuilder = Attributes.builder();
-            DistroMetadata.getMetadata().forEach(attributesBuilder::put);
+            DistroMetadata.getMetadata().forEach(resourceAttributes::put);
             if (StringUtils.isNotEmpty(serviceName)) {
-                attributesBuilder.put(EnvironmentConfiguration.SERVICE_NAME_FIELD, serviceName);
+                resourceAttributes.put(EnvironmentConfiguration.SERVICE_NAME_FIELD, serviceName);
             }
             tracerProviderBuilder.setResource(
-                Resource.create(attributesBuilder.build()));
+                Resource.create(resourceAttributes.build()));
 
             if (propagators == null) {
                 propagators = ContextPropagators.create(W3CTraceContextPropagator.getInstance());

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/HoneycombSdk.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/HoneycombSdk.java
@@ -160,6 +160,9 @@ public final class HoneycombSdk implements OpenTelemetry {
         /**
          * Add a string attribute as a resource attribute.
          *
+         * @param key The key to associate a value with
+         * @param value The value to store as an attribute
+         *
          * @return AttributesBuilder
          */
         public AttributesBuilder addResourceAttribute(String key, String value) {
@@ -168,6 +171,9 @@ public final class HoneycombSdk implements OpenTelemetry {
 
         /**
          * Add a long attribute as a resource attribute.
+         *
+         * @param key The key to associate a value with
+         * @param value The value to store as an attribute
          *
          * @return AttributesBuilder
          */
@@ -178,6 +184,9 @@ public final class HoneycombSdk implements OpenTelemetry {
         /**
          * Add a double attribute as a resource attribute.
          *
+         * @param key The key to associate a value with
+         * @param value The value to store as an attribute
+         *
          * @return AttributesBuilder
          */
         public AttributesBuilder addResourceAttribute(String key, double value) {
@@ -187,6 +196,9 @@ public final class HoneycombSdk implements OpenTelemetry {
         /**
          * Add a boolean attribute as a resource attribute.
          *
+         * @param key The key to associate a value with
+         * @param value The value to store as an attribute
+         *
          * @return AttributesBuilder
          */
         public AttributesBuilder addResourceAttribute(String key, boolean value) {
@@ -195,6 +207,9 @@ public final class HoneycombSdk implements OpenTelemetry {
 
         /**
          * Add a String array attribute as a resource attribute.
+         *
+         * @param key The key to associate a value with
+         * @param value The value to store as an attribute
          *
          * @return AttributesBuilder
          */


### PR DESCRIPTION
Fixes #37. Creating methods for adding arbitrary resource attributes to the builder. We already use resource attributes to store the service name, so this just adds an AttributeBuilder to the Sdk builder which collects a list of attributes that the user can add to.

```java
HoneycombSdk honeycomb = new HoneycombSdk.Builder()
    .setApiKey(YOUR_API_KEY)
    .setDataset(YOUR_DATASET)
    .setServiceName(YOUR_SERVICE_NAME)
    .addResourceAttribute("java.version", System.getProperty("java.version")) // optional
    .build();
```

This will result in a resource with attributes "`service.name`" and "`java.version`". 
