### PR TITLE
Fix Sontaype pom validator

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,19 @@
 
 1. Once the above changes are merged into `main`, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off CI, which will publish a draft GitHub release, and stage the new release in [Sonatype](https://oss.sonatype.org).
 
-1. You should now see the new release in Sonatype UI under `Staging Repositories`. Select the release, and "Close" it. That will do some validation. Once that's done, you should be able to "Release" it to make it available in Maven. See more details in [Sonatype docs](https://help.sonatype.com/repomanager2/staging-releases/managing-staging-repositories).
+1. You should now see the new release in Sonatype UI under `Staging Repositories`. Select the release, and "Close" it. That will do some validation.
+
+1. Once the repo is closed, you can test the staged artifacts by pointing a test app at the staging group:
+
+    ```groovy
+    repositories {
+        maven {
+            url = uri("https://oss.sonatype.org/content/groups/staging/")
+        }
+    }
+    ```
+
+1. Once the staged repo is closed, you should be able to "Release" it to make it available in Maven. See more details in [Sonatype docs](https://help.sonatype.com/repomanager2/staging-releases/managing-staging-repositories).
 
 1. Update Release Notes on the new draft GitHub release, and publish that.
 

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -6,6 +6,7 @@ plugins {
 apply from: "$rootDir/gradle/shadow.gradle"
 
 def artifactName = "honeycomb-opentelemetry-javaagent"
+description = 'Honeycomb distribution of the OpenTelemetry auto-instrumentation agent.'
 def relocatePackages = ext.relocatePackages
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,10 @@ subprojects {
                     }
                     pom {
                         name = 'Honeycomb OpenTelemetry Distribution for Java'
-                        description = 'Honeycomb distribution of the OpenTelemetry Java Instrumentation.'
                         url = 'https://github.com/honeycombio/honeycomb-opentelemetry-java'
+                        afterEvaluate {
+                            description = project.description
+                        }
                         licenses {
                             license {
                                 name = 'The Apache License, Version 2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ subprojects {
                     }
                     pom {
                         name = 'Honeycomb OpenTelemetry Distribution for Java'
+                        description = 'Honeycomb distribution of the OpenTelemetry Java Instrumentation.'
                         url = 'https://github.com/honeycombio/honeycomb-opentelemetry-java'
                         licenses {
                             license {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 def artifactName = "honeycomb-opentelemetry-common"
+description = 'Functionality shared across components of the Honeycomb OpenTelemetry distribution.'
 
 jar {
     archivesBaseName = "${artifactName}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 def artifactName = "honeycomb-opentelemetry-sdk"
+description = 'Honeycomb SDK for manually configuring OpenTelemetry instrumentation.'
 
 test {
     useJUnitPlatform()


### PR DESCRIPTION
* add description to POMs
* add note about testing staged artifacts
* Fixes #64 

Tested locally: publish to Sonatype, close (validation passed), use in test app.