### PR TITLE
Add opentelemetry-extension-annotations as api dependency in the sdk

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,6 +12,7 @@ test {
 
 dependencies {
     api "io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}"
+    api "io.opentelemetry:opentelemetry-extension-annotations:${versions.opentelemetry}"
 
     implementation "io.opentelemetry:opentelemetry-exporter-otlp:${versions.opentelemetry}"
     implementation 'io.grpc:grpc-netty-shaded:1.37.0'


### PR DESCRIPTION
So users only need to depend on the Honey SDK when enriching their code with spans and attributes