### PR TITLE
Disable metrics by default

### DIFF
--- a/agent/src/main/java/io/honeycomb/opentelemetry/HoneycombAgent.java
+++ b/agent/src/main/java/io/honeycomb/opentelemetry/HoneycombAgent.java
@@ -35,11 +35,11 @@ public class HoneycombAgent {
         if (!isPresent(dataset)) {
             System.out.printf("WARN: %s%n", EnvironmentConfiguration.getErrorMessage("dataset", EnvironmentConfiguration.HONEYCOMB_DATASET));
         }
-        
+
         if (isPresent(apiKey) && isPresent(dataset)) {
             System.setProperty("otel.exporter.otlp.headers",
-            String.format("%s=%s,%s=%s", EnvironmentConfiguration.HONEYCOMB_TEAM_HEADER, apiKey,
-            EnvironmentConfiguration.HONEYCOMB_DATASET_HEADER, dataset));
+                String.format("%s=%s,%s=%s", EnvironmentConfiguration.HONEYCOMB_TEAM_HEADER, apiKey,
+                    EnvironmentConfiguration.HONEYCOMB_DATASET_HEADER, dataset));
         }
 
         // metrics not currently supported in this distro

--- a/agent/src/main/java/io/honeycomb/opentelemetry/HoneycombAgent.java
+++ b/agent/src/main/java/io/honeycomb/opentelemetry/HoneycombAgent.java
@@ -35,12 +35,16 @@ public class HoneycombAgent {
         if (!isPresent(dataset)) {
             System.out.printf("WARN: %s%n", EnvironmentConfiguration.getErrorMessage("dataset", EnvironmentConfiguration.HONEYCOMB_DATASET));
         }
-
+        
         if (isPresent(apiKey) && isPresent(dataset)) {
             System.setProperty("otel.exporter.otlp.headers",
-                String.format("%s=%s,%s=%s", EnvironmentConfiguration.HONEYCOMB_TEAM_HEADER, apiKey,
-                    EnvironmentConfiguration.HONEYCOMB_DATASET_HEADER, dataset));
+            String.format("%s=%s,%s=%s", EnvironmentConfiguration.HONEYCOMB_TEAM_HEADER, apiKey,
+            EnvironmentConfiguration.HONEYCOMB_DATASET_HEADER, dataset));
         }
+
+        // metrics not currently supported in this distro
+        System.setProperty("otel.metrics.exporter", "none");
+
         System.setProperty("otel.exporter.otlp.endpoint", apiEndpoint);
     }
 


### PR DESCRIPTION
Fixes #90 .

Metrics are not yet configured in the Honeycomb OTEL Java Distribution. This disables metrics by default until configuration is added. 