### PR TITLE
Update start-date on stalebot to be Sept 1

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          start-date: '2021-01-09T00:00:00Z'
+          start-date: '2021-09-01T00:00:00Z'
           stale-issue-message: 'Marking this issue as stale because it has been open 14 days with no activity. Please add a comment if this is still an ongoing issue; otherwise this issue will be automatically closed in 7 days.'
           stale-pr-message: 'Marking this PR as stale because it has been open 30 days with no activity. Please add a comment if this PR is still relevant; otherwise this PR will be automatically closed in 7 days.'
           close-issue-message: 'Closing this issue due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'


### PR DESCRIPTION

## Short description of the changes

- Update Stalebot to actually be Sept 1, not January 9. Copy pasta of incorrect example for date format.

