### PR TITLE
Update OpenTelemetry SDK to 1.5.0 and agent to 1.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This is Honeycomb's distribution of OpenTelemetry for Java.
 It makes getting started with OpenTelemetry and Honeycomb easier!
 
 Latest release built with:
-- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.5.0) version 1.5.0
-- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.5.3) version 1.5.3
+- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.2.0) version 1.2.0
+- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.2.0) version 1.2.0
 
 ## Why would I want to use this?
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This is Honeycomb's distribution of OpenTelemetry for Java.
 It makes getting started with OpenTelemetry and Honeycomb easier!
 
 Latest release built with:
-- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.2.0) version 1.2.0
-- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.2.0) version 1.2.0
+- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.5.0) version 1.5.0
+- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.5.3) version 1.5.3
 
 ## Why would I want to use this?
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry         : "1.2.0",
-                opentelemetryJavaagent: "1.2.0",
+                opentelemetry         : "1.5.0",
+                opentelemetryJavaagent: "1.5.3",
                 bytebuddy             : "1.10.18",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"


### PR DESCRIPTION
## Which problem is this PR solving?
Updates the OpenTelemetry SDK and agent to newer versions. While v1.6.0 of the SDK is available, I updated to v1.5.0 because that matches the latest agent and it's good to keep them in step.

## Short description of the changes
- update OpenTelemetry SDK and agent dependencies to 1.5.0/1.5.3 respectively