### PR TITLE
Add support for enabling OTel metrics

### DIFF
--- a/agent/src/main/java/io/honeycomb/opentelemetry/HoneycombAgent.java
+++ b/agent/src/main/java/io/honeycomb/opentelemetry/HoneycombAgent.java
@@ -4,8 +4,6 @@ import io.opentelemetry.javaagent.OpenTelemetryAgent;
 
 import java.lang.instrument.Instrumentation;
 
-import static io.honeycomb.opentelemetry.EnvironmentConfiguration.isPresent;
-
 /**
  * Honeycomb wrapper around {@link OpenTelemetryAgent}.
  *
@@ -24,28 +22,8 @@ public class HoneycombAgent {
     }
 
     private static void configureEnvironment() {
-
-        final String apiKey = EnvironmentConfiguration.getHoneycombApiKey();
-        final String apiEndpoint = EnvironmentConfiguration.getHoneycombApiEndpoint();
-        final String dataset = EnvironmentConfiguration.getHoneycombDataset();
-
-        if (!isPresent(apiKey)) {
-            System.out.printf("WARN: %s%n", EnvironmentConfiguration.getErrorMessage("API key", EnvironmentConfiguration.HONEYCOMB_API_KEY));
-        }
-        if (!isPresent(dataset)) {
-            System.out.printf("WARN: %s%n", EnvironmentConfiguration.getErrorMessage("dataset", EnvironmentConfiguration.HONEYCOMB_DATASET));
-        }
-
-        if (isPresent(apiKey) && isPresent(dataset)) {
-            System.setProperty("otel.exporter.otlp.headers",
-                String.format("%s=%s,%s=%s", EnvironmentConfiguration.HONEYCOMB_TEAM_HEADER, apiKey,
-                    EnvironmentConfiguration.HONEYCOMB_DATASET_HEADER, dataset));
-        }
-
-        // metrics not currently supported in this distro
-        System.setProperty("otel.metrics.exporter", "none");
-
-        System.setProperty("otel.exporter.otlp.endpoint", apiEndpoint);
+        // set sytem properties to configre OTLP exporter to send traces & metrics data
+        EnvironmentConfiguration.enableOTLPTraces();
+        EnvironmentConfiguration.enableOTLPMetrics();
     }
-
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -6,6 +6,10 @@ plugins {
 def artifactName = "honeycomb-opentelemetry-common"
 description = 'Functionality shared across components of the Honeycomb OpenTelemetry distribution.'
 
+dependencies {
+    implementation 'com.google.guava:guava:30.1.1-jre'
+}
+
 jar {
     archivesBaseName = "${artifactName}"
 }

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -177,9 +177,19 @@ public class EnvironmentConfiguration {
     }
 
     public static void enableOTLPMetrics() {
-        final String endpoint = getHoneycombMetricsApiEndpoint();
-        final String apiKey = getHoneycombMetricsApiKey();
-        final String dataset = getHoneycombMetricsDataset();
+        enableOTLPMetrics(null, null, null);
+    }
+
+    public static void enableOTLPMetrics(String endpoint, String apiKey, String dataset) {
+        if (Strings.isNullOrEmpty(endpoint)) {
+            endpoint = getHoneycombMetricsApiEndpoint();
+        }
+        if (Strings.isNullOrEmpty(apiKey)) {
+            apiKey = getHoneycombMetricsApiKey();
+        }
+        if (Strings.isNullOrEmpty(dataset)) {
+            dataset = getHoneycombMetricsDataset();
+        }
 
         if (!Strings.isNullOrEmpty(dataset)) {
             System.setProperty("otel.exporter.otlp.metrics.endpoint", endpoint);

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -177,19 +177,9 @@ public class EnvironmentConfiguration {
     }
 
     public static void enableOTLPMetrics() {
-        enableOTLPMetrics(null, null, null);
-    }
-
-    public static void enableOTLPMetrics(String endpoint, String apiKey, String dataset) {
-        if (Strings.isNullOrEmpty(endpoint)) {
-            endpoint = getHoneycombMetricsApiEndpoint();
-        }
-        if (Strings.isNullOrEmpty(apiKey)) {
-            apiKey = getHoneycombMetricsApiKey();
-        }
-        if (Strings.isNullOrEmpty(dataset)) {
-            dataset = getHoneycombMetricsDataset();
-        }
+        final String endpoint = getHoneycombMetricsApiEndpoint();
+        final String apiKey = getHoneycombMetricsApiKey();
+        final String dataset = getHoneycombMetricsDataset();
 
         if (!Strings.isNullOrEmpty(dataset)) {
             System.setProperty("otel.exporter.otlp.metrics.endpoint", endpoint);

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -10,8 +10,8 @@ import com.google.common.base.Strings;
 public class EnvironmentConfiguration {
 
     public static final String HONEYCOMB_API_KEY = "HONEYCOMB_API_KEY";
-    public static final String HONEYCOMB_TRACES_API_KEY = "HONEYCOMB_TRACES_APIKEY";
-    public static final String HONEYCOMB_METRICS_API_KEY = "HONEYCOMB_METRICS_APIKEY";
+    public static final String HONEYCOMB_TRACES_APIKEY = "HONEYCOMB_TRACES_APIKEY";
+    public static final String HONEYCOMB_METRICS_APIKEY = "HONEYCOMB_METRICS_APIKEY";
     public static final String HONEYCOMB_API_ENDPOINT = "HONEYCOMB_API_ENDPOINT";
     public static final String HONEYCOMB_TRACES_ENDPOINT = "HONEYCOMB_TRACES_ENDPOINT";
     public static final String HONEYCOMB_METRICS_ENDPOINT = "HONEYCOMB_METRICS_ENDPOINT";
@@ -37,19 +37,19 @@ public class EnvironmentConfiguration {
     /**
      * Reads the Honeycomb API key to send trace data.
      *
-     * @return honeycomb.api.key system property or HONEYCOMB_API_KEY environment variable
+     * @return honeycomb.traces.apikey system property or HONEYCOMB_TRACES_APIKEY environment variable
      */
     public static String getHoneycombTracesApiKey() {
-        return readVariable(HONEYCOMB_API_KEY, getHoneycombApiKey());
+        return readVariable(HONEYCOMB_TRACES_APIKEY, getHoneycombApiKey());
     }
 
     /**
      * Reads the Honeycomb API key to send metrics data.
      *
-     * @return honeycomb.api.key system property or HONEYCOMB_API_KEY environment variable
+     * @return honeycomb.metrics.apikey system property or HONEYCOMB_METRICS_APIKEY environment variable
      */
     public static String getHoneycombMetricsApiKey() {
-        return readVariable(HONEYCOMB_METRICS_API_KEY, getHoneycombApiKey());
+        return readVariable(HONEYCOMB_METRICS_APIKEY, getHoneycombApiKey());
     }
 
     /**
@@ -64,7 +64,7 @@ public class EnvironmentConfiguration {
     /**
      * Reads the Honeycomb API endpoint to send trace data.
      *
-     * @return honeycomb.api.key system property or HONEYCOMB_API_KEY environment variable
+     * @return honeycomb.traces.endpoint system property or HONEYCOMB_TRACES_ENDPOINT environment variable
      */
     public static String getHoneycombTracesApiEndpoint() {
         return readVariable(HONEYCOMB_TRACES_ENDPOINT, getHoneycombApiEndpoint());
@@ -73,7 +73,7 @@ public class EnvironmentConfiguration {
     /**
      * Reads the Honeycomb API endpoint to send metrics data.
      *
-     * @return honeycomb.api.key system property or HONEYCOMB_API_KEY environment variable
+     * @return honeycomb.metrics.endpoint system property or HONEYCOMB_METRICS_ENDPOINT environment variable
      */
     public static String getHoneycombMetricsApiEndpoint() {
         return readVariable(HONEYCOMB_METRICS_ENDPOINT, getHoneycombApiEndpoint());
@@ -91,7 +91,7 @@ public class EnvironmentConfiguration {
     /**
      * Read the Honeycomb dataset to store trace data.
      *
-     * @return honeycomb.metrics.dataset system property or HONEYCOMB_METRICS_DATASET environment variable
+     * @return honeycomb.traces.dataset system property or HONEYCOMB_TRACES_DATASET environment variable
      */
     public static String getHoneycombTracesDataset() {
         return readVariable(HONEYCOMB_TRACES_DATASET, getHoneycombDataset());
@@ -103,7 +103,7 @@ public class EnvironmentConfiguration {
      * @return honeycomb.metrics.dataset system property or HONEYCOMB_METRICS_DATASET environment variable
      */
     public static String getHoneycombMetricsDataset() {
-        return readVariable(HONEYCOMB_DATASET, null); // don't default to generic dataset like we do for apikey and endpoint
+        return readVariable(HONEYCOMB_METRICS_DATASET, null); // don't default to generic dataset like we do for apikey and endpoint
     }
 
     /**

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -1,5 +1,7 @@
 package io.honeycomb.opentelemetry;
 
+import com.google.common.base.Strings;
+
 /**
  * This is a utility class that helps read Honeycomb environment variables and system properties.
  * <p>
@@ -8,8 +10,14 @@ package io.honeycomb.opentelemetry;
 public class EnvironmentConfiguration {
 
     public static final String HONEYCOMB_API_KEY = "HONEYCOMB_API_KEY";
+    public static final String HONEYCOMB_TRACES_API_KEY = "HONEYCOMB_TRACES_APIKEY";
+    public static final String HONEYCOMB_METRICS_API_KEY = "HONEYCOMB_METRICS_APIKEY";
     public static final String HONEYCOMB_API_ENDPOINT = "HONEYCOMB_API_ENDPOINT";
+    public static final String HONEYCOMB_TRACES_ENDPOINT = "HONEYCOMB_TRACES_ENDPOINT";
+    public static final String HONEYCOMB_METRICS_ENDPOINT = "HONEYCOMB_METRICS_ENDPOINT";
     public static final String HONEYCOMB_DATASET = "HONEYCOMB_DATASET";
+    public static final String HONEYCOMB_TRACES_DATASET = "HONEYCOMB_TRACES_DATASET";
+    public static final String HONEYCOMB_METRICS_DATASET = "HONEYCOMB_METRICS_DATASET";
     public static final String SERVICE_NAME = "SERVICE_NAME";
     public static final String SAMPLE_RATE = "SAMPLE_RATE";
     public static final String DEFAULT_HONEYCOMB_ENDPOINT = "https://api.honeycomb.io:443";
@@ -27,6 +35,24 @@ public class EnvironmentConfiguration {
     }
 
     /**
+     * Reads the Honeycomb API key to send trace data.
+     *
+     * @return honeycomb.api.key system property or HONEYCOMB_API_KEY environment variable
+     */
+    public static String getHoneycombTracesApiKey() {
+        return readVariable(HONEYCOMB_API_KEY, getHoneycombApiKey());
+    }
+
+    /**
+     * Reads the Honeycomb API key to send metrics data.
+     *
+     * @return honeycomb.api.key system property or HONEYCOMB_API_KEY environment variable
+     */
+    public static String getHoneycombMetricsApiKey() {
+        return readVariable(HONEYCOMB_METRICS_API_KEY, getHoneycombApiKey());
+    }
+
+    /**
      * Read the Honeycomb API endpoint.
      *
      * @return honeycomb.api.endpoint system property or HONEYCOMB_API_ENDPOINT environment variable
@@ -36,12 +62,48 @@ public class EnvironmentConfiguration {
     }
 
     /**
+     * Reads the Honeycomb API endpoint to send trace data.
+     *
+     * @return honeycomb.api.key system property or HONEYCOMB_API_KEY environment variable
+     */
+    public static String getHoneycombTracesApiEndpoint() {
+        return readVariable(HONEYCOMB_TRACES_ENDPOINT, getHoneycombApiEndpoint());
+    }
+
+    /**
+     * Reads the Honeycomb API endpoint to send metrics data.
+     *
+     * @return honeycomb.api.key system property or HONEYCOMB_API_KEY environment variable
+     */
+    public static String getHoneycombMetricsApiEndpoint() {
+        return readVariable(HONEYCOMB_METRICS_ENDPOINT, getHoneycombApiEndpoint());
+    }
+
+    /**
      * Read the Honeycomb dataset name.
      *
      * @return honeycomb.dataset system property or HONEYCOMB_DATASET environment variable
      */
     public static String getHoneycombDataset() {
         return readVariable(HONEYCOMB_DATASET, null);
+    }
+
+    /**
+     * Read the Honeycomb dataset to store trace data.
+     *
+     * @return honeycomb.metrics.dataset system property or HONEYCOMB_METRICS_DATASET environment variable
+     */
+    public static String getHoneycombTracesDataset() {
+        return readVariable(HONEYCOMB_TRACES_DATASET, getHoneycombDataset());
+    }
+
+    /**
+     * Read the Honeycomb dataset to store metrics data.
+     *
+     * @return honeycomb.metrics.dataset system property or HONEYCOMB_METRICS_DATASET environment variable
+     */
+    public static String getHoneycombMetricsDataset() {
+        return readVariable(HONEYCOMB_DATASET, null); // don't default to generic dataset like we do for apikey and endpoint
     }
 
     /**
@@ -93,5 +155,41 @@ public class EnvironmentConfiguration {
 
     private static String getPropertyName(String envKey) {
         return envKey.toLowerCase().replace('_', '.');
+    }
+
+    public static void enableOTLPTraces() {
+        final String endpoint = getHoneycombTracesApiEndpoint();
+        final String apiKey = getHoneycombTracesApiKey();
+        final String dataset = getHoneycombTracesDataset();
+
+        if (!isPresent(apiKey)) {
+            System.out.printf("WARN: %s%n", getErrorMessage("API key", HONEYCOMB_API_KEY));
+        }
+        if (!isPresent(dataset)) {
+            System.out.printf("WARN: %s%n", getErrorMessage("dataset", HONEYCOMB_DATASET));
+        }
+
+        System.setProperty("otel.exporter.otlp.traces.endpoint", endpoint);
+        System.setProperty("otel.exporter.otlp.traces.headers",
+            String.format("%s=%s,%s=%s",
+                HONEYCOMB_TEAM_HEADER, apiKey,
+                HONEYCOMB_DATASET_HEADER, dataset));
+    }
+
+    public static void enableOTLPMetrics() {
+        final String endpoint = getHoneycombMetricsApiEndpoint();
+        final String apiKey = getHoneycombMetricsApiKey();
+        final String dataset = getHoneycombMetricsDataset();
+
+        if (!Strings.isNullOrEmpty(dataset)) {
+            System.setProperty("otel.exporter.otlp.metrics.endpoint", endpoint);
+            System.setProperty("otel.exporter.otlp.metrics.headers",
+                String.format("%s=%s,%s=%s",
+                    HONEYCOMB_TEAM_HEADER, apiKey,
+                    HONEYCOMB_DATASET_HEADER, dataset));
+        } else {
+            // setting to "none" disables metrics
+            System.setProperty("otel.metrics.exporter", "none");
+        }
     }
 }

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/HoneycombSdk.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/HoneycombSdk.java
@@ -2,6 +2,7 @@ package io.honeycomb.opentelemetry;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+
 import io.honeycomb.opentelemetry.sdk.trace.spanprocessors.BaggageSpanProcessor;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -65,10 +66,13 @@ public final class HoneycombSdk implements OpenTelemetry {
         private final List<SpanProcessor> additionalSpanProcessors = new ArrayList<>();
         private AttributesBuilder resourceAttributes = Attributes.builder();
 
-        private String apiKey;
-        private String dataset;
-        private String endpoint;
+        private String tracesApiKey;
+        private String tracesDataset;
+        private String tracesEndpoint;
         private String serviceName;
+        private String metricsApiKey;
+        private String metricsEndpoint;
+        private String metricsDataset;
 
         /**
          * Sets the Honeycomb API Key to use.
@@ -80,7 +84,36 @@ public final class HoneycombSdk implements OpenTelemetry {
          * @return builder
          */
         public Builder setApiKey(String apiKey) {
-            this.apiKey = apiKey;
+            setTracesApiKey(apiKey);
+            setMetricsApiKey(apiKey);
+            return this;
+        }
+
+        /**
+         * Sets the Honeycomb API key to send trace data.
+         *
+         * <p>This value is sent to Honeycomb on every request and is used to identify
+         * the team making a request.</p>
+         *
+         * @param apiKey a String to use as the API key. See team settings in Honeycomb.
+         * @return builder
+         */
+        public Builder setTracesApiKey(String apiKey) {
+            this.tracesApiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * Sets the Honeycomb API Key to send metrics data.
+         *
+         * <p>This value is sent to Honeycomb on every request and is used to identify
+         * the team making a request.</p>
+         *
+         * @param apiKey a String to use as the API key. See team settings in Honeycomb.
+         * @return builder
+         */
+        public Builder setMetricsApiKey(String apiKey) {
+            this.metricsApiKey = apiKey;
             return this;
         }
 
@@ -94,7 +127,34 @@ public final class HoneycombSdk implements OpenTelemetry {
          * @return builder
          */
         public Builder setDataset(String dataset) {
-            this.dataset = dataset;
+            setTracesDataset(dataset);
+            // don't set metrics dataset, we want them to go to different places
+            return this;
+        }
+
+        /**
+         * Sets the Honeycomb dataset to store trace data.
+         *
+         * <p>This value is sent to Honeycomb on every request and is used to identify
+         * the dataset that metrics data is being written to.</p>
+         * @param dataset a String to use as the metrics dataset name.
+         * @return builder
+         */
+        public Builder setTracesDataset(String dataset) {
+            this.tracesDataset = dataset;
+            return this;
+        }
+
+        /**
+         * Sets the Honeycomb dataset to store metics data.
+         *
+         * <p>This value is sent to Honeycomb on every request and is used to identify
+         * the dataset that metrics data is being written to.</p>
+         * @param dataset a String to use as the metrics dataset name.
+         * @return builder
+         */
+        public Builder setMetricsDataset(String dataset) {
+            this.metricsDataset = dataset;
             return this;
         }
 
@@ -105,7 +165,30 @@ public final class HoneycombSdk implements OpenTelemetry {
          * @return builder
          */
         public Builder setEndpoint(String endpoint) {
-            this.endpoint = endpoint;
+            setTracesEndpoint(endpoint);
+            setMetricsEndpoint(endpoint);
+            return this;
+        }
+
+        /**
+         * Sets the Honeycomb endpoint to send trace data. Optional, defaults to the Honeycomb ingest API.
+         *
+         * @param endpoint a String to use as the endpoint URI. Must begin with https or http.
+         * @return builder
+         */
+        public Builder setTracesEndpoint(String endpoint) {
+            this.tracesEndpoint = endpoint;
+            return this;
+        }
+
+        /**
+         * Sets the Honeycomb endpoint to send metrics data.. Optional, defaults to the Honeycomb ingest API.
+         *
+         * @param endpoint a String to use as the endpoint URI. Must begin with https or http.
+         * @return builder
+         */
+        public Builder setMetricsEndpoint(String endpoint) {
+            this.metricsEndpoint = endpoint;
             return this;
         }
 
@@ -253,27 +336,27 @@ public final class HoneycombSdk implements OpenTelemetry {
 
             Logger logger = Logger.getLogger(HoneycombSdk.class.getName());
 
-            if (!isPresent(apiKey)) {
+            if (!isPresent(tracesApiKey)) {
                 logger.warning(EnvironmentConfiguration.getErrorMessage("API key",
                     EnvironmentConfiguration.HONEYCOMB_API_KEY));
             }
-            if (!isPresent(dataset)) {
+            if (!isPresent(tracesDataset)) {
                 logger.warning(EnvironmentConfiguration.getErrorMessage("dataset",
                     EnvironmentConfiguration.HONEYCOMB_DATASET));
             }
 
             OtlpGrpcSpanExporterBuilder builder = OtlpGrpcSpanExporter.builder();
 
-            if (endpoint != null) {
-                builder.setEndpoint(endpoint);
+            if (tracesEndpoint != null) {
+                builder.setEndpoint(tracesEndpoint);
             } else {
                 builder.setEndpoint(EnvironmentConfiguration.DEFAULT_HONEYCOMB_ENDPOINT);
             }
 
-            if (isPresent(apiKey) && isPresent(dataset)) {
+            if (isPresent(tracesApiKey) && isPresent(tracesDataset)) {
                 builder
-                    .addHeader(EnvironmentConfiguration.HONEYCOMB_TEAM_HEADER, apiKey)
-                    .addHeader(EnvironmentConfiguration.HONEYCOMB_DATASET_HEADER, dataset);
+                    .addHeader(EnvironmentConfiguration.HONEYCOMB_TEAM_HEADER, tracesApiKey)
+                    .addHeader(EnvironmentConfiguration.HONEYCOMB_DATASET_HEADER, tracesDataset);
             }
             SpanExporter exporter = builder.build();
 
@@ -296,6 +379,7 @@ public final class HoneycombSdk implements OpenTelemetry {
                         W3CBaggagePropagator.getInstance()));
             }
 
+            EnvironmentConfiguration.enableOTLPMetrics(metricsEndpoint, metricsApiKey, metricsDataset);
             return new HoneycombSdk(tracerProviderBuilder.build(), propagators);
         }
     }

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -44,9 +44,6 @@ public final class OpenTelemetryConfiguration {
         private String tracesDataset;
         private String tracesEndpoint;
         private String serviceName;
-        private String metricsApiKey;
-        private String metricsEndpoint;
-        private String metricsDataset;
 
         private Builder() {}
 
@@ -61,7 +58,6 @@ public final class OpenTelemetryConfiguration {
          */
         public Builder setApiKey(String apiKey) {
             setTracesApiKey(apiKey);
-            setMetricsApiKey(apiKey);
             return this;
         }
 
@@ -76,20 +72,6 @@ public final class OpenTelemetryConfiguration {
          */
         public Builder setTracesApiKey(String apiKey) {
             this.tracesApiKey = apiKey;
-            return this;
-        }
-
-        /**
-         * Sets the Honeycomb API Key to send metrics data.
-         *
-         * <p>This value is sent to Honeycomb on every request and is used to identify
-         * the team making a request.</p>
-         *
-         * @param apiKey a String to use as the API key. See team settings in Honeycomb.
-         * @return builder
-         */
-        public Builder setMetricsApiKey(String apiKey) {
-            this.metricsApiKey = apiKey;
             return this;
         }
 
@@ -122,19 +104,6 @@ public final class OpenTelemetryConfiguration {
         }
 
         /**
-         * Sets the Honeycomb dataset to store metics data.
-         *
-         * <p>This value is sent to Honeycomb on every request and is used to identify
-         * the dataset that metrics data is being written to.</p>
-         * @param dataset a String to use as the metrics dataset name.
-         * @return builder
-         */
-        public Builder setMetricsDataset(String dataset) {
-            this.metricsDataset = dataset;
-            return this;
-        }
-
-        /**
          * Sets the Honeycomb endpoint to use. Optional, defaults to the Honeycomb ingest API.
          *
          * @param endpoint a String to use as the endpoint URI. Must begin with https or http.
@@ -142,7 +111,6 @@ public final class OpenTelemetryConfiguration {
          */
         public Builder setEndpoint(String endpoint) {
             setTracesEndpoint(endpoint);
-            setMetricsEndpoint(endpoint);
             return this;
         }
 
@@ -154,17 +122,6 @@ public final class OpenTelemetryConfiguration {
          */
         public Builder setTracesEndpoint(String endpoint) {
             this.tracesEndpoint = endpoint;
-            return this;
-        }
-
-        /**
-         * Sets the Honeycomb endpoint to send metrics data.. Optional, defaults to the Honeycomb ingest API.
-         *
-         * @param endpoint a String to use as the endpoint URI. Must begin with https or http.
-         * @return builder
-         */
-        public Builder setMetricsEndpoint(String endpoint) {
-            this.metricsEndpoint = endpoint;
             return this;
         }
 
@@ -355,7 +312,6 @@ public final class OpenTelemetryConfiguration {
                         W3CBaggagePropagator.getInstance()));
             }
 
-            EnvironmentConfiguration.enableOTLPMetrics(metricsEndpoint, metricsApiKey, metricsDataset);
             return OpenTelemetrySdk.builder()
                 .setTracerProvider(tracerProviderBuilder.build())
                 .setPropagators(propagators)


### PR DESCRIPTION
## Which problem is this PR solving?
OTel metrics were disabled in the HoneycombAgent wrapper (#92) because metrics should be sent to different datasets than trace data. However there was only one way to specify the a dataset so both trace and metrics data was being sent to the same dataset.

This change adds support for enabling metrics in agent mode by setting a metrics dataset, and optionally set a different endpoint and API key by providing some new system properties or environment variables

- Closes #96 

## Short description of the changes
- add options for setting trace and metrics endpoint, API key and dataset vis system properties and env vars
- new system properties and env vars will fall back to the original system properties / env vars so they are backward compatible
- If a MetricsDataset is set, we enable the metrics OTLP exporter via setting [OTLP defined system properties](https://github.com/open-telemetry/opentelemetry-java/tree/e8f054615e2f99e345408000b40010587140c581/sdk-extensions/autoconfigure#otlp-exporter-both-span-and-metric-exporters)

NOTE 1: Enabling metrics when using the OpenTelemetryConfiguration.Builder to instrument manually is not supported. This is because the Java SDK Metrics interface for creating the provider and instruments is still under-development. Any application using our configurator would have to create those resources manually, which would likely include the OTLP exporter too. Once the Java SDK metrics interface is stable, we can revisit.

NOTE 2: I've intentionally shortened the new traces and metrics env var names for API keys because it felt weird setting system properties like `honeycomb.traces.api.key` where `honeycomb.traces.apikey` felt nicer.

NOTE 3: I have not updated the README with new env vars / system properties as part of this PR because they may confuse anyone coming to the project between these changes being merged and being released.