### PR TITLE
automate nexus publish/close/release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           steps:
             - run:
                 name: "Publish Artifacts to Maven"
-                command: ./gradlew publish
+                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
 
 filters_always: &filters_always
   filters:

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+}
+
 allprojects {
     project.group = "io.honeycomb"
     project.version = "0.4.0"
@@ -18,8 +22,8 @@ subprojects {
         versions.opentelemetryJavaagentAlpha = "${versions.opentelemetryJavaagent}-alpha"
 
         deps = [
-                bytebuddy           : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: versions.bytebuddy),
-                bytebuddyagent      : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy-agent', version: versions.bytebuddy),
+                bytebuddy     : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: versions.bytebuddy),
+                bytebuddyagent: dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy-agent', version: versions.bytebuddy),
         ]
     }
 
@@ -84,17 +88,6 @@ subprojects {
                     }
                 }
             }
-            repositories {
-                maven {
-                    def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-                    def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
-                    url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-                    credentials {
-                        username = System.getenv("OSSRH_USERNAME")
-                        password = System.getenv("OSSRH_PASSWORD")
-                    }
-                }
-            }
         }
 
         if (!project.hasProperty("skip.signing")) {
@@ -114,5 +107,14 @@ subprojects {
             }
         }
 
+    }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            username.set(System.getenv("OSSRH_USERNAME"))
+            password.set(System.getenv("OSSRH_PASSWORD"))
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- publishing to maven still requires manually closing/releasing the artifacts after CI does the "publish" task

## Short description of the changes

- use the nexus-publish plugin to automate the rest of the process
- verified from my machine that publish and close works (didn't want to actually release anything)
- will update releasing.md next time we do a release and confirm that everything works as expected
- fixes #66 

