### PR TITLE
Mike/document debug agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ java \
 -javaagent:honeycomb-opentelemetry-javaagent-0.4.0-all.jar -jar myapp.jar
 ```
 
+## Troubleshooting
+
+To enable debugging when running with the OpenTelemetry Java Agent, you can set the `otel.javaagent.debug` system property or `OTEL_JAVAAGENT_DEBUG` environment variable to `true`.
+When this setting is provided, the Agent configures a [LoggingSpanExporter](https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/logging) that logs traces & metrics data.
+
 ## SDK Usage
 
 For teams that opt not to use the agent for auto-instrumentation,

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     api "io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}"
     api "io.opentelemetry:opentelemetry-extension-annotations:${versions.opentelemetry}"
 
+    implementation "io.opentelemetry:opentelemetry-exporter-logging:${versions.opentelemetry}"
     implementation "io.opentelemetry:opentelemetry-exporter-otlp:${versions.opentelemetry}"
     implementation 'io.grpc:grpc-netty-shaded:1.40.0'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'


### PR DESCRIPTION
## Which problem is this PR solving?
Adds documentation on how to enable the debug mode when using the Java agent and extends the SDK configurator to add a `enableDebug` option that works in a similar way.

- Closes #91 

## Short description of the changes
- Updates README with instructions on how to enable the agent debug flag (system property & environment variable)
- Adds `enableDebug` option SDK configurator builder that creates and registers a LoggingSpanExporter when set to `true`

NOTE: I have not added the new `enableDebug` configurator option to our docs yet. The agent debug mode is already available in the agent, so can be added straight away.
