### PR TITLE
Ensure SDK configurator applies core SDK resource attributes

### DIFF
--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -303,7 +303,7 @@ public final class OpenTelemetryConfiguration {
                 resourceAttributes.put(EnvironmentConfiguration.SERVICE_NAME_FIELD, serviceName);
             }
             tracerProviderBuilder.setResource(
-                Resource.create(resourceAttributes.build()));
+                Resource.getDefault().merge(Resource.create(resourceAttributes.build())));
 
             if (propagators == null) {
                 propagators = ContextPropagators.create(


### PR DESCRIPTION
## Which problem is this PR solving?
The `telemtry.sdk.{name, language, version}` resource attributes are missing when creating traces using the manually configured OpenTelemetry SDK using the OpenTelemetryConfiguration.builder. We should include the base OpenTelemetry SDKs attributes so both we and the user applications can see that information.

- Closes #116 

## Short description of the changes
- Updates the manual builder to merge the default Resource with the one we create with our own `distro` attributes.

Before and after:
![Screen Shot 2021-09-20 at 15 02 45](https://user-images.githubusercontent.com/3481731/134016562-5c172548-dd72-485f-88c0-876d1298124c.png)