### PR TITLE
Bump otel to 1.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ subprojects {
     ext {
         versions = [
                 opentelemetry         : "1.6.0",
-                opentelemetryJavaagent: "1.5.3",
+                opentelemetryJavaagent: "1.6.0",
                 bytebuddy             : "1.10.18",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry         : "1.5.0",
+                opentelemetry         : "1.6.0",
                 opentelemetryJavaagent: "1.5.3",
                 bytebuddy             : "1.10.18",
         ]

--- a/custom/src/main/java/io/honeycomb/opentelemetry/DistroMetadataResourceProvider.java
+++ b/custom/src/main/java/io/honeycomb/opentelemetry/DistroMetadataResourceProvider.java
@@ -2,7 +2,7 @@ package io.honeycomb.opentelemetry;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
 

--- a/custom/src/main/java/io/honeycomb/opentelemetry/HoneycombSdkTracerProviderConfigurer.java
+++ b/custom/src/main/java/io/honeycomb/opentelemetry/HoneycombSdkTracerProviderConfigurer.java
@@ -2,12 +2,9 @@ package io.honeycomb.opentelemetry;
 
 import io.honeycomb.opentelemetry.sdk.trace.samplers.DeterministicTraceSampler;
 import io.honeycomb.opentelemetry.sdk.trace.spanprocessors.BaggageSpanProcessor;
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.sdk.autoconfigure.spi.SdkTracerProviderConfigurer;
-import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Honeycomb implementation of {@link SdkTracerProviderConfigurer} SPI.
@@ -16,7 +13,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class HoneycombSdkTracerProviderConfigurer implements SdkTracerProviderConfigurer {
     @Override
-    public void configure(SdkTracerProviderBuilder tracerProvider) {
+    public void configure(SdkTracerProviderBuilder tracerProvider, ConfigProperties config) {
         int sampleRate;
         try {
             sampleRate = EnvironmentConfiguration.getSampleRate();

--- a/custom/src/main/java/io/honeycomb/opentelemetry/ServiceNameResourceProvider.java
+++ b/custom/src/main/java/io/honeycomb/opentelemetry/ServiceNameResourceProvider.java
@@ -2,7 +2,7 @@ package io.honeycomb.opentelemetry;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import org.apache.commons.lang3.StringUtils;


### PR DESCRIPTION
branching from dependabot to get an extra set of eyes, see [update to the example distro](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4120/files)

- Closes #140 