### PR TITLE
Add attribute to indicate source of telemetry data

### DIFF
--- a/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
@@ -23,17 +23,22 @@ public class DistroMetadata {
     private static final String LANGUAGE_VALUE = "java";
     private static final String RUNTIME_VERSION_FIELD = "honeycomb.distro.runtime_version";
     private static final String RUNTIME_VERSION_VALUE = System.getProperty("java.version");
+    private static final String SOURCE = "honeycomb.distro.source";
+
+    public static final String SDK_SOURCE = "sdk";
+    public static final String AGENT_SOURCE = "agent";
 
     /**
      * Get Metadata as a map of strings to strings.
      *
      * @return map of metadata to include as resource attributes.
      */
-    public static Map<String, String> getMetadata() {
+    public static Map<String, String> getMetadata(String source) {
         Map<String, String> metadata = new HashMap<String, String>();
         metadata.put(VERSION_FIELD, VERSION_VALUE);
         metadata.put(LANGUAGE_FIELD, LANGUAGE_VALUE);
         metadata.put(RUNTIME_VERSION_FIELD, RUNTIME_VERSION_VALUE);
+        metadata.put(SOURCE, source);
         return metadata;
     }
 }

--- a/custom/src/main/java/io/honeycomb/opentelemetry/DistroMetadataResourceProvider.java
+++ b/custom/src/main/java/io/honeycomb/opentelemetry/DistroMetadataResourceProvider.java
@@ -10,7 +10,7 @@ public class DistroMetadataResourceProvider implements ResourceProvider {
     @Override
     public Resource createResource(ConfigProperties config) {
         AttributesBuilder attributesBuilder = Attributes.builder();
-        DistroMetadata.getMetadata().forEach(attributesBuilder::put);
+        DistroMetadata.getMetadata(DistroMetadata.AGENT_SOURCE).forEach(attributesBuilder::put);
         return Resource.create(attributesBuilder.build());
     }
 }

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -316,7 +316,7 @@ public final class OpenTelemetryConfiguration {
 
             this.additionalSpanProcessors.forEach(tracerProviderBuilder::addSpanProcessor);
 
-            DistroMetadata.getMetadata().forEach(resourceAttributes::put);
+            DistroMetadata.getMetadata(DistroMetadata.SDK_SOURCE).forEach(resourceAttributes::put);
             if (StringUtils.isNotEmpty(serviceName)) {
                 resourceAttributes.put(EnvironmentConfiguration.SERVICE_NAME_FIELD, serviceName);
             }


### PR DESCRIPTION
## Which problem is this PR solving?
Provides a way to indicate whether the java app was configured using the manual SDK or the agent by adding a new `honeycomb.distro.source` attribute, where the values are set to either `sdk` or `agent`.
- Closes #131 

## Short description of the changes
- Update DistroMetadata.getMetadata to take source as parameter
- Set new `honeycomb.distro.source` attribute using parameter
- Update SDK and agent configuration to set the source when getting metadata

Examples query
![image](https://user-images.githubusercontent.com/3481731/134514355-5ef9d525-8062-4ba6-8fcf-09ce3663a2f6.png)
