### PR TITLE
Use built-in OTel resources for OS & runtime

### DIFF
--- a/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
@@ -19,10 +19,6 @@ public class DistroMetadata {
      * Java agent.
      */
     private static final String VERSION_VALUE = "0.4.0";
-    private static final String LANGUAGE_FIELD = "honeycomb.distro.language";
-    private static final String LANGUAGE_VALUE = "java";
-    private static final String RUNTIME_VERSION_FIELD = "honeycomb.distro.runtime_version";
-    private static final String RUNTIME_VERSION_VALUE = System.getProperty("java.version");
 
     /**
      * Get Metadata as a map of strings to strings.
@@ -32,8 +28,6 @@ public class DistroMetadata {
     public static Map<String, String> getMetadata() {
         Map<String, String> metadata = new HashMap<String, String>();
         metadata.put(VERSION_FIELD, VERSION_VALUE);
-        metadata.put(LANGUAGE_FIELD, LANGUAGE_VALUE);
-        metadata.put(RUNTIME_VERSION_FIELD, RUNTIME_VERSION_VALUE);
         return metadata;
     }
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 
     implementation "io.opentelemetry:opentelemetry-exporter-logging:${versions.opentelemetry}"
     implementation "io.opentelemetry:opentelemetry-exporter-otlp:${versions.opentelemetry}"
+    implementation "io.opentelemetry:opentelemetry-sdk-extension-resources:${versions.opentelemetry}"
+
     implementation 'io.grpc:grpc-netty-shaded:1.41.0'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'com.google.guava:guava:30.1.1-jre'

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -14,6 +14,8 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
+import io.opentelemetry.sdk.extension.resources.OsResource;
+import io.opentelemetry.sdk.extension.resources.ProcessRuntimeResource;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -323,7 +325,10 @@ public final class OpenTelemetryConfiguration {
                 resourceAttributes.put(EnvironmentConfiguration.SERVICE_NAME_FIELD, serviceName);
             }
             tracerProviderBuilder.setResource(
-                Resource.getDefault().merge(Resource.create(resourceAttributes.build())));
+                Resource.getDefault()
+                    .merge(OsResource.get())
+                    .merge(ProcessRuntimeResource.get())
+                    .merge(Resource.create(resourceAttributes.build())));
 
             if (propagators == null) {
                 propagators = ContextPropagators.create(


### PR DESCRIPTION
## Which problem is this PR solving?
We currently try to capture the process runtime using a custom attribute when configured to run with the OTel SDK. This PR removes the custom attributes and uses built-in OTel resources that capture OS and runtime attributes.

## Short description of the changes
- Remove custom attributes from DistroMetadata for language and runtime
- Import OTel SDK resource extensions package
- Merge OsResource and RuntimeResource when building the Resource to use for the SDK

NOTE: These are the same resources that are automatically configured and used when running with the agent.