### PR TITLE
fix: metrics export

### DIFF
--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -129,7 +129,7 @@ public class EnvironmentConfiguration {
      * Get a friendly error message for missing variable.
      *
      * @param humanKey human-friendly variable description
-     * @param key environment variable key
+     * @param key      environment variable key
      * @return missing variable error message
      */
     public static String getErrorMessage(String humanKey, String key) {
@@ -182,14 +182,12 @@ public class EnvironmentConfiguration {
         final String dataset = getHoneycombMetricsDataset();
 
         if (!Strings.isNullOrEmpty(dataset)) {
+            System.setProperty("otel.metrics.exporter", "otlp");
             System.setProperty("otel.exporter.otlp.metrics.endpoint", endpoint);
             System.setProperty("otel.exporter.otlp.metrics.headers",
                 String.format("%s=%s,%s=%s",
                     HONEYCOMB_TEAM_HEADER, apiKey,
                     HONEYCOMB_DATASET_HEADER, dataset));
-        } else {
-            // setting to "none" disables metrics
-            System.setProperty("otel.metrics.exporter", "none");
         }
     }
 }


### PR DESCRIPTION
- otel 1.6.0 defaults otel.metrics.exporter to "none"

<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- metrics export broke after upgrading to otel 1.6.0 

## Short description of the changes

- enable the `otel.metrics.exporter` when honeycomb metrics dataset is configured
- no longer necessary to explicitly disable metrics otherwise

