### PR TITLE
docs: sonatype release is automated

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,24 +4,10 @@
 
 2. If the new release updates the OpenTelemetry SDK and/or agent versions, update the `Latest release built with` section in the [README](./README.md).
 
-3. Once the above changes are merged into `main`, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off CI, which will publish a draft GitHub release, and stage the new release in [Sonatype](https://oss.sonatype.org).
+3. Once the above changes are merged into `main`, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off CI, which will publish a draft GitHub release, and publish to Maven.
 
-4. You should now see the new release in Sonatype UI under `Staging Repositories`. Select the release, and "Close" it. That will do some validation.
+4. Update Release Notes on the new draft GitHub release, and publish that.
 
-5. Once the repo is closed, you can test the staged artifacts by pointing a test app at the staging group:
-
-    ```groovy
-    repositories {
-        maven {
-            url = uri("https://oss.sonatype.org/content/groups/staging/")
-        }
-    }
-    ```
-
-6. Once the staged repo is closed, you should be able to "Release" it to make it available in Maven. See more details in [Sonatype docs](https://help.sonatype.com/repomanager2/staging-releases/managing-staging-repositories).
-
-7. Update Release Notes on the new draft GitHub release, and publish that.
-
-8. Update public docs with the new version.
+5. Update public docs with the new version.
 
 Voila!


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- verified with latest release that the new gradle plugin published, closed, and released the new version to Maven

## Short description of the changes

-

