### PR TITLE
re-add java runtime version distro metadata

### DIFF
--- a/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
@@ -19,6 +19,8 @@ public class DistroMetadata {
      * Java agent.
      */
     private static final String VERSION_VALUE = "0.5.0";
+    private static final String RUNTIME_VERSION_FIELD = "honeycomb.distro.runtime_version";
+    private static final String RUNTIME_VERSION_VALUE = System.getProperty("java.runtime.version");
 
     /**
      * Get Metadata as a map of strings to strings.
@@ -28,6 +30,7 @@ public class DistroMetadata {
     public static Map<String, String> getMetadata() {
         Map<String, String> metadata = new HashMap<String, String>();
         metadata.put(VERSION_FIELD, VERSION_VALUE);
+        metadata.put(RUNTIME_VERSION_FIELD, RUNTIME_VERSION_VALUE);
         return metadata;
     }
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Re-adds the java runtime distro metadata field that was removed in a previous PR.

- Resolves #157 

## Short description of the changes
- Re-add the `honeycomb.distro.runtime` field with the value that is the same as the [OTEL SDK](https://github.com/open-telemetry/opentelemetry-java/blob/df1f47d9298efa755a4bff358e2c34b0f1de7770/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ProcessRuntimeResource.java#L30)

