### PR TITLE
fix: Remove google guava dep that suppressed gRPC

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -6,10 +6,6 @@ plugins {
 def artifactName = "honeycomb-opentelemetry-common"
 description = 'Functionality shared across components of the Honeycomb OpenTelemetry distribution.'
 
-dependencies {
-    implementation 'com.google.guava:guava:30.1.1-jre'
-}
-
 jar {
     archivesBaseName = "${artifactName}"
 }

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -179,7 +179,7 @@ public class EnvironmentConfiguration {
         final String apiKey = getHoneycombMetricsApiKey();
         final String dataset = getHoneycombMetricsDataset();
 
-        if (dataset != null) {
+        if (isPresent(dataset)) {
             System.setProperty("otel.metrics.exporter", "otlp");
             System.setProperty("otel.exporter.otlp.metrics.endpoint", endpoint);
             System.setProperty("otel.exporter.otlp.metrics.headers",

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -1,7 +1,5 @@
 package io.honeycomb.opentelemetry;
 
-import com.google.common.base.Strings;
-
 /**
  * This is a utility class that helps read Honeycomb environment variables and system properties.
  * <p>
@@ -181,11 +179,11 @@ public class EnvironmentConfiguration {
         final String apiKey = getHoneycombMetricsApiKey();
         final String dataset = getHoneycombMetricsDataset();
 
-        if (!Strings.isNullOrEmpty(dataset)) {
+        if (dataset != null) {
             System.setProperty("otel.metrics.exporter", "otlp");
             System.setProperty("otel.exporter.otlp.metrics.endpoint", endpoint);
             System.setProperty("otel.exporter.otlp.metrics.headers",
-                String.format("%s=%s,%s=%s",
+                    String.format("%s=%s,%s=%s",
                     HONEYCOMB_TEAM_HEADER, apiKey,
                     HONEYCOMB_DATASET_HEADER, dataset));
         }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #158 
- In [v0.5.0](https://github.com/honeycombio/honeycomb-opentelemetry-java/releases/tag/v0.5.0) we enabled support for metrics, and introduced a new dependency on `com.google.guava:guava:30.1.1-jre` to detect the existence of a metrics dataset. Somehow this library prevents the agent from working on its own without manually adding a dependency on gRPC (either via direct dependency or transitive through sdk).

## Short description of the changes

- This PR removes that dependency, but still checks whether the metrics dataset variable is null.

To confirm it works, remove the `:sdk` dependency and manual instrumenting from the spring-agent example app, and `../../gradlew bootRun` from sprint-agent directory. Curling the endpoint should produce telemetry in honeycomb (enable `OTEL_JAVAAGENT_DEBUG` to see in console as well).

