### PR TITLE
[docs] Update notes around SDK and gRPC usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,25 +129,6 @@ public class ExampleController {
 }
 ```
 
-### Multi-span Attributes
-
-Sometimes you'll want to add the same attribute to many spans
-within the same trace.
-We'll leverage the OpenTelemetry concept of
-[Baggage](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#baggage-signal)
-to do that.
-
-Use this to add a `key` with a `value` as an attribute
-to every subsequent child span of the current application context.
-
-```java
-Baggage.current()
-    .toBuilder()
-    .put(key, value)
-    .build()
-    .makeCurrent();
-```
-
 ### Resource Attributes
 
 Sometimes you'll want one or more attributes set on all spans within a service.
@@ -186,6 +167,47 @@ for sending manual OpenTelemetry instrumentation to Honeycomb.
 The SDK also provides a deterministic sampler and more span processing options.
 
 [Set up the Honeycomb OpenTelemetry SDK for Java](https://docs.honeycomb.io/getting-data-in/java/opentelemetry-distro/#using-the-honeycomb-sdk-builder).
+
+### Multi-span Attributes
+
+Sometimes you'll want to add the same attribute to many spans
+within the same trace.
+We'll leverage the OpenTelemetry concept of
+[Baggage](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#baggage-signal)
+to do that.
+
+Use this to add a `key` with a `value` as an attribute
+to every subsequent child span of the current application context.
+
+Be sure to initialize the `OpenTelemetryConfiguration.builder()`
+with a `BaggageSpanProcessor`:
+
+```java
+import io.honeycomb.opentelemetry.OpenTelemetryConfiguration;
+import io.honeycomb.opentelemetry.sdk.trace.spanprocessors.BaggageSpanProcessor;
+
+@Bean
+public OpenTelemetry honeycomb() {
+    return OpenTelemetryConfiguration.builder()
+        .addSpanProcessor(new BaggageSpanProcessor())
+        .setApiKey(System.getenv("HONEYCOMB_API_KEY"))
+        .setDataset(System.getenv("HONEYCOMB_DATASET"))
+        .setServiceName(System.getenv("SERVICE_NAME"))
+        .setEndpoint(System.getenv("HONEYCOMB_API_ENDPOINT"))
+        .buildAndRegisterGlobal();
+    }
+```
+
+In your code, import `io.opentelemetry.api.baggage.Baggage`
+to allow use of the `Baggage` class.
+
+```java
+Baggage.current()
+    .toBuilder()
+    .put(key, value)
+    .build()
+    .makeCurrent();
+```
 
 ### gRPC transport customization
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,43 @@ The SDK also provides a deterministic sampler and more span processing options.
 
 [Set up the Honeycomb OpenTelemetry SDK for Java](https://docs.honeycomb.io/getting-data-in/java/opentelemetry-distro/#using-the-honeycomb-sdk-builder).
 
+### gRPC transport customization
+
+A gRPC transport is required to transmit OpenTelemetry data.
+HoneycombSDK includes `grpc-netty-shaded`.
+If you'd like to use another gRPC transport,
+you can exclude the `grpc-netty-shaded` transitive dependency:
+
+#### Maven, excluding `grpc-netty-shaded`
+
+```xml
+<project>
+    <dependencies>
+        <dependency>
+            <groupId>io.honeycomb</groupId>
+            <artifactId>honeycomb-opentelemetry-sdk</artifactId>
+            <version>0.5.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-netty-shaded</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+#### Gradle, excluding `grpc-netty-shaded`
+
+```groovy
+dependencies {
+    implementation('io.honeycomb:honeycomb-opentelemetry-sdk:0.5.0') {
+        exclude group: 'io.grpc', module: 'grpc-netty-shaded'
+    }
+}
+```
+
 ## License
 
 [Apache 2.0 License](./LICENSE).


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Partially closes #159 

## Short description of the changes

- Some notes about gRPC versions were in the docs directory and have been added to the README - specifically pointing out that there can be gRPC version conflicts and if a user wants to use a different gRPC library, it can be excluded in the dependencies.
- The section about multi-span attributes has been moved to the SDK usage section because it requires the `BaggageSpanProcessor` be added to the `OpenTelemetryConfiguration.builder()`.
- Other note: I will also be submitting a PR to the docs to reflect these changes 

