### PR TITLE
Always add baggage processor to SDK processors

### DIFF
--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -41,9 +41,9 @@ public final class OpenTelemetryConfiguration {
     public static class Builder {
         private ContextPropagators propagators;
         private Sampler sampler = Sampler.alwaysOn();
-        private final List<SpanProcessor> additionalSpanProcessors = new ArrayList<>(
-            List.of(new BaggageSpanProcessor())
-        );
+        private final List<SpanProcessor> additionalSpanProcessors = new ArrayList<SpanProcessor>() {{
+            add(new BaggageSpanProcessor());
+        }};
         private AttributesBuilder resourceAttributes = Attributes.builder();
         private Boolean enableDebug = false;
 


### PR DESCRIPTION
## Which problem is this PR solving?
We always want to add the baggage processor when configuring the SDK, like we do for the agent. This PR adds the BaggageProcessor to the list of processors when the configuration builder is first created.

## Short description of the changes
- Adds a BaggageProcessor to the list of processors during configuration builder init
- Update `addProcessor` code docs