### PR TITLE
Prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # honeycomb-opentelemetry-java changelog
 
+## [0.6.0] - 2021-10-08
+
+### Enhancements
+
+- Always add baggage processor to SDK processors (#169) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+
+### Fixes
+
+- Remove google guava dep that suppressed gRPC (#162) | [@JamieDanielson](https://github.com/JamieDanielson)
+- re-add java runtime version distro metadata (#160) | [@vreynolds](https://github.com/vreynolds)
+
+### Maintenance
+
+- Clear the way; docs are in docs now (#171) | [@JamieDanielson](https://github.com/JamieDanielson)
+- Update notes around SDK and gRPC usage (#166) | [@JamieDanielson](https://github.com/JamieDanielson)
+- Add example app for testing agent-only usage (#165) | [@JamieDanielson](https://github.com/JamieDanielson)
+- add Java 17 to test matrix (#156) | [@vreynolds](https://github.com/vreynolds)
+- sonatype release is automated (#155) | [@vreynolds](https://github.com/vreynolds)
+
 ## [0.5.0] - 2021-09-27
 
 ### !!! Breaking Changes !!!

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -57,11 +57,11 @@ Your local Maven repository is located at `~/.m2/repository/`.
 Go there to inspect your build artifacts:
 
 ```sh
-$ cd ~/.m2/repository/io/honeycomb/honeycomb-opentelemetry-sdk/0.5.0
+$ cd ~/.m2/repository/io/honeycomb/honeycomb-opentelemetry-sdk/0.6.0
 $ ls -1
-honeycomb-opentelemetry-sdk-0.5.0.jar
-honeycomb-opentelemetry-sdk-0.5.0.module
-honeycomb-opentelemetry-sdk-0.5.0.pom
+honeycomb-opentelemetry-sdk-0.6.0.jar
+honeycomb-opentelemetry-sdk-0.6.0.module
+honeycomb-opentelemetry-sdk-0.6.0.pom
 maven-metadata-local.xml
 ```
 
@@ -79,6 +79,6 @@ repositories {
 }
 
 dependencies {
-    implementation('io.honeycomb:honeycomb-opentelemetry-sdk:0.5.0')
+    implementation('io.honeycomb:honeycomb-opentelemetry-sdk:0.6.0')
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     project.group = "io.honeycomb"
-    project.version = "0.5.0"
+    project.version = "0.6.0"
 }
 
 subprojects {

--- a/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
@@ -18,7 +18,7 @@ public class DistroMetadata {
      * with the version number and read it, but that isn't possible from the
      * Java agent.
      */
-    private static final String VERSION_VALUE = "0.5.0";
+    private static final String VERSION_VALUE = "0.6.0";
     private static final String RUNTIME_VERSION_FIELD = "honeycomb.distro.runtime_version";
     private static final String RUNTIME_VERSION_VALUE = System.getProperty("java.runtime.version");
 


### PR DESCRIPTION
## Which problem is this PR solving?
Prepare the v0.6.0 release.

## Short description of the changes
- Update version numbers 0.5.0 -> 0.6.0
- Update DEVELOPMENT.md guide to use newest version
- Update CHANGELOG.md with changes
