### PR TITLE
Vera.jars jars jars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             - run: mkdir -p ~/artifacts
             - run:
                 name: "Publish Artifacts to Maven"
-                command: ./gradlew publishToSonatype
+                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --dry-run
             - run: cp **/build/libs/*.jar ~/artifacts
             - persist_to_workspace:
                 root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,7 @@ jobs:
       - checkout
       - gradle/with_cache:
           steps:
-            - run: mkdir -p ~/artifacts
             - run: ./gradlew build -x test
-            - run: cp **/build/libs/*.jar ~/artifacts
-            - persist_to_workspace:
-                root: ~/
-                paths:
-                  - artifacts
-            - store_artifacts:
-                path: ~/artifacts
   publish_github:
     docker:
       - image: cibuilds/github:0.13.0
@@ -40,9 +32,17 @@ jobs:
       - checkout
       - gradle/with_cache:
           steps:
+            - run: mkdir -p ~/artifacts
             - run:
                 name: "Publish Artifacts to Maven"
                 command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+            - run: cp **/build/libs/*.jar ~/artifacts
+            - persist_to_workspace:
+                root: ~/
+                paths:
+                  - artifacts
+            - store_artifacts:
+                path: ~/artifacts
 
 filters_always: &filters_always
   filters:
@@ -92,7 +92,7 @@ workflows:
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:
-            - build
+            - publish_maven
           <<: *filters_publish
       - publish_maven:
           context: java_beeline

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             - run: mkdir -p ~/artifacts
             - run:
                 name: "Publish Artifacts to Maven"
-                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --dry-run
+                command: ./gradlew publishToSonatype
             - run: cp **/build/libs/*.jar ~/artifacts
             - persist_to_workspace:
                 root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             - run: mkdir -p ~/artifacts
             - run:
                 name: "Publish Artifacts to Maven"
-                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --dry-run
+                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
             - run: cp **/build/libs/*.jar ~/artifacts
             - persist_to_workspace:
                 root: ~/
@@ -98,6 +98,4 @@ workflows:
           context: java_beeline
           requires:
             - build
-          filters:
-            branches:
-              only: vera.jars-jars-jars
+          <<: *filters_publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             - run: mkdir -p ~/artifacts
             - run:
                 name: "Publish Artifacts to Maven"
-                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --dry-run
             - run: cp **/build/libs/*.jar ~/artifacts
             - persist_to_workspace:
                 root: ~/
@@ -98,4 +98,6 @@ workflows:
           context: java_beeline
           requires:
             - build
-          <<: *filters_publish
+          filters:
+            branches:
+              only: vera.jars-jars-jars

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     project.group = "io.honeycomb"
-    project.version = "0.6.0"
+    project.version = "0.6.0-SNAPSHOT"
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     project.group = "io.honeycomb"
-    project.version = "0.6.0-SNAPSHOT"
+    project.version = "0.6.0"
 }
 
 subprojects {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Restructure CI to do a Maven release first, followed by GitHub release
- Ensures GH release uses the exact same artifacts created in Maven release job
- Closes #170 and #173 

## Short description of the changes

- test release job: https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-java/575/workflows/2ded3e89-4f48-432c-a810-3285e24d4d7b/jobs/2035/artifacts

