### PR TITLE
Return OpenTelemetryConfiguration.Builder when adding resource attributes

### DIFF
--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -201,10 +201,11 @@ public final class OpenTelemetryConfiguration {
          *
          * @param key   The key to associate a value with
          * @param value The value to store as an attribute
-         * @return AttributesBuilder
+         * @return Builder
          */
-        public AttributesBuilder addResourceAttribute(String key, String value) {
-            return this.resourceAttributes.put(key, value);
+        public Builder addResourceAttribute(String key, String value) {
+            this.resourceAttributes.put(key, value);
+            return this;
         }
 
         /**
@@ -212,10 +213,11 @@ public final class OpenTelemetryConfiguration {
          *
          * @param key   The key to associate a value with
          * @param value The value to store as an attribute
-         * @return AttributesBuilder
+         * @return Builder
          */
-        public AttributesBuilder addResourceAttribute(String key, long value) {
-            return this.resourceAttributes.put(key, value);
+        public Builder addResourceAttribute(String key, long value) {
+            this.resourceAttributes.put(key, value);
+            return this;
         }
 
         /**
@@ -223,10 +225,11 @@ public final class OpenTelemetryConfiguration {
          *
          * @param key   The key to associate a value with
          * @param value The value to store as an attribute
-         * @return AttributesBuilder
+         * @return Builder
          */
-        public AttributesBuilder addResourceAttribute(String key, double value) {
-            return this.resourceAttributes.put(key, value);
+        public Builder addResourceAttribute(String key, double value) {
+            this.resourceAttributes.put(key, value);
+            return this;
         }
 
         /**
@@ -234,10 +237,11 @@ public final class OpenTelemetryConfiguration {
          *
          * @param key   The key to associate a value with
          * @param value The value to store as an attribute
-         * @return AttributesBuilder
+         * @return Builder
          */
-        public AttributesBuilder addResourceAttribute(String key, boolean value) {
-            return this.resourceAttributes.put(key, value);
+        public Builder addResourceAttribute(String key, boolean value) {
+            this.resourceAttributes.put(key, value);
+            return this;
         }
 
         /**
@@ -245,10 +249,11 @@ public final class OpenTelemetryConfiguration {
          *
          * @param key   The key to associate a value with
          * @param value The value to store as an attribute
-         * @return AttributesBuilder
+         * @return Builder
          */
-        public AttributesBuilder addResourceAttribute(String key, String... value) {
-            return this.resourceAttributes.put(key, value);
+        public Builder addResourceAttribute(String key, String... value) {
+            this.resourceAttributes.put(key, value);
+            return this;
         }
 
         /**

--- a/sdk/src/test/java/io/honeycomb/opentelemetry/OpenTelemetryConfigurationTest.java
+++ b/sdk/src/test/java/io/honeycomb/opentelemetry/OpenTelemetryConfigurationTest.java
@@ -5,6 +5,7 @@ import io.honeycomb.opentelemetry.sdk.trace.spanprocessors.BaggageSpanProcessor;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 
 import org.junit.jupiter.api.AfterEach;
@@ -57,4 +58,22 @@ public class OpenTelemetryConfigurationTest {
         // sent as gRPC metadata.
     }
 
+    @Test
+    void testConfiguration_addAttributes() {
+        // NOTE: this does not verify the attributes are added correctly to
+        // the resource, but does exercise the interface to ensure it is
+        // can be used fluently (eg chain OpenTelemetryconfiguration.Builder calls)
+        OpenTelemetry openTelemetry = OpenTelemetryConfiguration.builder()
+            .addResourceAttribute("str", "str")
+            .addResourceAttribute("bool", true)
+            .addResourceAttribute("int", 123)
+            .addResourceAttribute("str-array", "str1", "str2", "str3")
+            .build();
+
+        Assertions.assertNotNull(openTelemetry);
+        // TODO: Figure out way to retrieve configured Resource from TracerProvider
+        // to verify resource attributes have been added correctly
+        // eg it might be possible using reflection
+        // https://stackoverflow.com/questions/8267964/how-to-access-package-private-class-from-a-class-in-some-other-package
+    }
 }


### PR DESCRIPTION
## Which problem is this PR solving?
When using `OpenTelemetryConfiguration.Builder` to add resource attributes, the `AttributesBuilder` is returned instead of the `Builder`. This means it is not possible to chain multiple calls to the top-level builder.

- Fixes #191 

## Short description of the changes
- update each of the `addResourceAttribute` overloads to return the top-level `Builder` instead of the `AttributesBuilder`
- add basic test to ensure the API can be used in the expected way

NOTE: The test does not actually verify that attributes are added to the resource as the `Resource` object is not available to retrieve from the `TracerProvider`. It may be possible to use reflection to do it later.

