### PR TITLE
teach gradle/make to display the project version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ build:
 test:
 	./gradlew test
 
+project_version:=$(shell grep 'project.version =' build.gradle | awk -F\" '{ print $$2 }')
+#: display the project's version
+project_version:
+	@echo ${project_version}
+
 dc-agent-only=docker-compose --file ./smoke-tests/smoke-tests-agent-only/docker-compose.yml
 dc-agent-manual=docker-compose --file ./smoke-tests/smoke-tests-agent-manual/docker-compose.yml
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,12 @@ allprojects {
     project.version = "0.6.1"
 }
 
+tasks.register('project_version') {
+    doLast {
+        println project.version
+    }
+}
+
 subprojects {
     version = rootProject.version
 


### PR DESCRIPTION
## Which problem is this PR solving?

A general sadness around non-Java tooling not knowing what the current project version is.

## Short description of the changes

This is a gradle task and a make target for looking up what the canonical version of the project is at the time. Something useful that shook out of [the Too Much Make experiment](https://github.com/honeycombio/honeycomb-opentelemetry-java/pull/195).

