### PR TITLE
Add support for properties files

### DIFF
--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -148,16 +148,18 @@ public class EnvironmentConfiguration {
     }
 
     private static String readVariable(String key, String fallback) {
+        // preference order is system prop -> env var -> config file, following the agent config order:
+        // https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/2fbec9331349650890620266e9c22512c9433986/docs/agent-config.md#configuring-the-agent
         String propertyName = getPropertyName(key);
-        String value = properties.getProperty(propertyName);
-        if (isPresent(value)) {
-            return value;
-        }
-        value = System.getProperty(propertyName);
+        String value = System.getProperty(propertyName);
         if (isPresent(value)) {
             return value;
         }
         value = System.getenv(key);
+        if (isPresent(value)) {
+            return value;
+        }
+        value = properties.getProperty(propertyName);
         if (isPresent(value)) {
             return value;
         }

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -150,11 +150,9 @@ public class EnvironmentConfiguration {
     private static String readVariable(String key, String fallback) {
         String propertyName = getPropertyName(key);
         String value;
-        if (propertyName != null) {
-            value = properties.getProperty(propertyName);
-            if (isPresent(value)) {
-                return value;
-            }
+        value = properties.getProperty(propertyName);
+        if (isPresent(value)) {
+            return value;
         }
         value = System.getProperty(propertyName);
         if (isPresent(value)) {

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -149,8 +149,7 @@ public class EnvironmentConfiguration {
 
     private static String readVariable(String key, String fallback) {
         String propertyName = getPropertyName(key);
-        String value;
-        value = properties.getProperty(propertyName);
+        String value = properties.getProperty(propertyName);
         if (isPresent(value)) {
             return value;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds support for providing configuration via a properties file. Also sets the otel system variable to the same path if one has not been set.

- Closes #14

NOTE: There are not tests for this yet, it probably makes sense to use a smoke test as this is related to setting system properties & env vars

## Short description of the changes
- Updates EnvironmentConfiguration to look for `honeycomb.config.file` system property then `HONEYCOMB_CONFIG_FILE` environment variable as properties file path
- If a path is found, loads the file into an instance of `Properties`
- Update `readVariable` to check the properties file, then system properties and then environment variables
- Sets `otel.javaagent.configuration-file` system property, if it's not already set, so OTel java agent will try to read from the same file

