### PR TITLE
Add smoke test for baggage span processor

### DIFF
--- a/examples/spring-agent-manual/src/main/java/io/honeycomb/examples/springbootagentmanual/HelloController.java
+++ b/examples/spring-agent-manual/src/main/java/io/honeycomb/examples/springbootagentmanual/HelloController.java
@@ -3,6 +3,7 @@ package io.honeycomb.examples.springbootagentmanual;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.extension.annotations.WithSpan;
 
@@ -14,6 +15,11 @@ public class HelloController {
     public String index() {
         Span span = Span.current();
         span.setAttribute("custom_field", "important value");
+        Baggage.current()
+            .toBuilder()
+            .put("for_the_children", "another important value")
+            .build()
+            .makeCurrent();
         String intro = getImportantInfo();
         String finalMessage = String.format("%s: Greetings from Spring Boot!", intro);
         return finalMessage;

--- a/smoke-tests/smoke-agent-manual.bats
+++ b/smoke-tests/smoke-agent-manual.bats
@@ -39,3 +39,8 @@ teardown() {
 	result=$(span_attributes_for "io.opentelemetry.spring-webmvc-3.1" | jq "select(.key == \"custom_field\").value.stringValue")
 	assert_equal "$result" '"important value"'
 }
+
+@test "BaggageSpanProcessor: key-values added to baggage appear on child spans" {
+	result=$(span_attributes_for "io.opentelemetry.opentelemetry-annotations-1.0" | jq "select(.key == \"for_the_children\").value.stringValue")
+	assert_equal "$result" '"another important value"'
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds a smoke test for the BaggageSpanProcessor to verify new spans have the expected attributes.

- Closes #190 
- Depends on #197

## Short description of the changes
- Updates spring-agent-manual example app to set a baggage attribute
- Add spring-agent-manual smoke test to verify the attribute is added to new span

PS @robbkidd dis all of this work, I just copy/pasted into new commit 😄 