### PR TITLE
Add Smoke test for JVM metric being emitted

### DIFF
--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -6,6 +6,8 @@ x-app-base: &app_base
     HONEYCOMB_API_ENDPOINT: http://collector:4317
     HONEYCOMB_API_KEY: bogus_key
     HONEYCOMB_DATASET: bogus_dataset
+    HONEYCOMB_METRICS_DATASET: bogus_dataset
+    OTEL_METRIC_EXPORT_INTERVAL: 1000
   command: "java -javaagent:/agent.jar -jar /app.jar"
   depends_on:
     - collector

--- a/smoke-tests/smoke-agent-only.bats
+++ b/smoke-tests/smoke-agent-only.bats
@@ -10,6 +10,11 @@ setup_file() {
 	wait_for_data
 }
 
+teardown_file() {
+	docker-compose restart collector
+	wait_for_flush
+}
+
 # TESTS
 
 @test "Auto instrumentation produces a Spring controller span" {
@@ -24,6 +29,6 @@ setup_file() {
 
 @test "Auto instrumentation emits metrics" {
 	wait_for_metrics 12
-	metric_names=$( metrics_received | jq ".metrics[].name" | wc -l | awk '{ print $1}' )
+	metric_names=$( metrics_received | jq ".instrumentationLibraryMetrics[].metrics[].name" | wc -l | awk '{ print $1}' )
 	[ "$metric_names" -ne 0 ]
 }

--- a/smoke-tests/smoke-agent-only.bats
+++ b/smoke-tests/smoke-agent-only.bats
@@ -8,10 +8,10 @@ setup_file() {
 	wait_for_ready_app 'app-agent-only'
 }
 
-setup() {
-	curl --silent "http://localhost:5002"
-	wait_for_data
-}
+# setup() {
+# 	curl --silent "http://localhost:5002"
+# 	wait_for_data
+# }
 
 teardown() {
 	docker-compose restart collector
@@ -20,12 +20,19 @@ teardown() {
 
 # TESTS
 
-@test "Auto instrumentation produces a Spring controller span" {
-	result=$(span_names_for "io.opentelemetry.spring-webmvc-3.1")
-	assert_equal "$result" '"HelloController.index"'
-}
+# @test "Auto instrumentation produces a Spring controller span" {
+# 	result=$(span_names_for "io.opentelemetry.spring-webmvc-3.1")
+# 	assert_equal "$result" '"HelloController.index"'
+# }
 
-@test "Auto instrumentation produces an incoming web request span" {
-	result=$(span_names_for "io.opentelemetry.tomcat-7.0")
-	assert_equal "$result" '"/"'
+# @test "Auto instrumentation produces an incoming web request span" {
+# 	result=$(span_names_for "io.opentelemetry.tomcat-7.0")
+# 	assert_equal "$result" '"/"'
+# }
+
+@test "SDK Trace metrics includes runtime.jvm.memory.area metric" {
+	sleep 30
+	result=$(metrics_from_library_named "io.opentelemetry.javaagent.shaded.instrumentation.runtimemetrics.MemoryPools" | jq "select(.name == \"runtime.jvm.memory.area\").name")
+	# echo " $result"  >&3
+	assert_equal "$result" '"runtime.jvm.memory.area"'
 }

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -6,6 +6,14 @@ spans_from_library_named() {
 			select(.instrumentationLibrary.name == \"$1\").spans[]" \
 		./collector/data.json
 }
+
+metrics_from_library_named() {
+	jq ".resourceMetrics[] |
+			.instrumentationLibraryMetrics[] |
+			select(.instrumentationLibrary.name == \"$1\").metrics[]" \
+		./collector/data.json
+}
+
 # test span name
 span_names_for() {
 	spans_from_library_named $1 | jq '.name'
@@ -17,6 +25,11 @@ span_attributes_for() {
 
 	spans_from_library_named $1 | \
 		jq ".attributes[]"
+}
+
+# test metric name
+metric_names_for() {
+	metrics_from_library_named $1 | jq '.name'
 }
 
 wait_for_data() {

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -1,19 +1,19 @@
 # UTILITY FUNCS
 
 spans_from_library_named() {
-	spans_received | jq "select(.instrumentationLibrary.name == \"$1\").spans[]"
+	spans_received | jq ".instrumentationLibrarySpans[] | select(.instrumentationLibrary.name == \"$1\").spans[]"
 }
 
 metrics_from_library_named() {
-	metrics_received | jq "select(.instrumentationLibrary.name == \"$1\").metrics[]"
+	metrics_received | jq ".instrumentationLibraryMetrics[] | select(.instrumentationLibrary.name == \"$1\").metrics[]"
 }
 
 spans_received() {
-	jq ".resourceSpans[].instrumentationLibrarySpans[]" ./collector/data.json
+	jq ".resourceSpans[]" ./collector/data.json
 }
 
 metrics_received() {
-	jq ".resourceMetrics[].instrumentationLibraryMetrics[]" ./collector/data.json
+	jq ".resourceMetrics[]" ./collector/data.json
 }
 
 # test span name


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- #168 

## Short description of the changes

- Metrics dataset added to all tests (though smoke only in agent-only scenario)
- Smoke test added to `smoke-agent-only` to check for existence of metrics
- More simplifying / breaking up of utility functions
- Each smoke test for a single example app uses a single instance of collector (instead of tearing down between tests)... but collector tears down between each example app smoke test
- Metrics have a shorter time interval specified to get results faster, and wait longer before checking for data
