### PR TITLE
Update DeterminisitcSampler to use OTel core Parent/TraceIDRatio samplers

### DIFF
--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -2,6 +2,7 @@ package io.honeycomb.opentelemetry;
 
 import com.google.common.base.Preconditions;
 
+import io.honeycomb.opentelemetry.sdk.trace.samplers.DeterministicTraceSampler;
 import io.honeycomb.opentelemetry.sdk.trace.spanprocessors.BaggageSpanProcessor;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -40,7 +41,7 @@ public final class OpenTelemetryConfiguration {
 
     public static class Builder {
         private ContextPropagators propagators;
-        private Sampler sampler = Sampler.alwaysOn();
+        private Sampler sampler = new DeterministicTraceSampler(1);
         private final List<SpanProcessor> additionalSpanProcessors = new ArrayList<SpanProcessor>() {{
             add(new BaggageSpanProcessor());
         }};
@@ -160,8 +161,8 @@ public final class OpenTelemetryConfiguration {
         /**
          * Sets the {@link Sampler} to use.
          *
-         * <p>Note that if no sampler is specified, AlwaysOnSampler
-         * will be used by default.</p>
+         * <p>Note that if no sampler is specified, a {@link DeterministicTraceSampler} with a
+         * sample rate of 1 (always sample) will be used by default.</p>
          *
          * @param sampler Sampler instance
          * @return builder

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
@@ -51,7 +51,7 @@ public class DeterministicTraceSampler implements Sampler {
      */
     public DeterministicTraceSampler(final int sampleRate) {
         this.sampleRate = sampleRate;
-        Double ratio;
+        double ratio;
         if (sampleRate == ALWAYS_SAMPLE) {
             ratio = 1.0;
         } else if (sampleRate == NEVER_SAMPLE) {

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
@@ -6,14 +6,8 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
-import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
 /**
@@ -40,12 +34,11 @@ import java.util.List;
  *      Nodejs sampler</a>
  */
 public class DeterministicTraceSampler implements Sampler {
-    private static final int MAX_U_INT = 0xffffffff;
     private static final int ALWAYS_SAMPLE = 1;
     private static final int NEVER_SAMPLE = 0;
 
+    private final Sampler baseSampler;
     private final int sampleRate;
-    private final int upperBound;
 
     public final static String DESCRIPTION = "HoneycombDeterministicSampler";
 
@@ -58,39 +51,15 @@ public class DeterministicTraceSampler implements Sampler {
      */
     public DeterministicTraceSampler(final int sampleRate) {
         this.sampleRate = sampleRate;
-        getSha(); // quick check that SHA-1 is available
-        upperBound = sampleRate == 0 ? 0 : Integer.divideUnsigned(MAX_U_INT, sampleRate);
-    }
-
-    /**
-     * Decides, based on the given traceId, whether to sample the current trace. 0
-     * if not, otherwise it returns the configured {@code sampleRate}.
-     *
-     * @param traceId to use as input to the sampling algorithm.
-     * @return a decision of whether the trace is to be sampled.
-     */
-    // @Override
-    public int sample(final String traceId) {
+        Double ratio;
         if (sampleRate == ALWAYS_SAMPLE) {
-            return 1;
+            ratio = 1.0;
+        } else if (sampleRate == NEVER_SAMPLE) {
+            ratio = 0.0;
+        } else {
+            ratio = 1.0 / sampleRate;
         }
-        if (sampleRate == NEVER_SAMPLE) {
-            return 0;
-        }
-        final MessageDigest sha = getSha();
-        sha.update(traceId.getBytes(StandardCharsets.UTF_8));
-        final byte[] digest = sha.digest();
-        final int first4Bytes = ByteBuffer.wrap(digest).order(ByteOrder.BIG_ENDIAN).getInt(0);
-        final boolean shouldSample = Integer.compareUnsigned(first4Bytes, upperBound) <= 0;
-        return shouldSample ? sampleRate : 0;
-    }
-
-    private MessageDigest getSha() {
-        try {
-            return MessageDigest.getInstance("SHA-1");
-        } catch (final NoSuchAlgorithmException e) { // very unlikely to happen!
-            throw new IllegalStateException("Failed to load SHA-1 algorithm", e);
-        }
+        baseSampler = Sampler.parentBased(Sampler.traceIdRatioBased(ratio));
     }
 
     @Override
@@ -107,34 +76,10 @@ public class DeterministicTraceSampler implements Sampler {
         Attributes attributes,
         List<LinkData> parentLinks) {
 
-        int sampleRate = sample(traceId);
-        return createResult(sampleRate);
-    }
-
-    protected SamplingResult createResult(int sampleRate) {
-        Attributes attrs = Attributes.of(AttributeKey.longKey("SampleRate"), (long) sampleRate);
-        SamplingDecision decision = sampleRate > 0 ? SamplingDecision.RECORD_AND_SAMPLE : SamplingDecision.DROP;
-
-        return new HoneycombSamplingResult(decision, attrs);
-    }
-
-    class HoneycombSamplingResult implements SamplingResult {
-        private final SamplingDecision decision;
-        private final Attributes attributes;
-
-        public HoneycombSamplingResult(final SamplingDecision decision, final Attributes attributes) {
-            this.decision = decision;
-            this.attributes = attributes;
-        }
-
-        @Override
-        public SamplingDecision getDecision() {
-            return decision;
-        }
-
-        @Override
-        public Attributes getAttributes() {
-            return attributes;
-        }
+        SamplingResult result = baseSampler.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+        return SamplingResult.create(
+            result.getDecision(),
+            Attributes.of(AttributeKey.longKey("SampleRate"), (long) sampleRate)
+        );
     }
 }

--- a/sdk/src/test/java/io/honeycomb/opentelemetry/DeterministicTraceSamplerTest.java
+++ b/sdk/src/test/java/io/honeycomb/opentelemetry/DeterministicTraceSamplerTest.java
@@ -1,18 +1,15 @@
 package io.honeycomb.opentelemetry;
 
 import java.util.Collections;
-import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import io.honeycomb.opentelemetry.sdk.trace.samplers.DeterministicTraceSampler;
 import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
@@ -43,36 +40,33 @@ public class DeterministicTraceSamplerTest {
         }
     }
 
-    @ParameterizedTest
-    @MethodSource("provideStringsForIsBlank")
-    public void test_trace_IDS_return_expected_result(String traceID, SamplingDecision expecteDecision) {
-        Sampler sampler = new DeterministicTraceSampler(2);
-        SamplingResult result = sampler.shouldSample(Context.current(), traceID, "span", SpanKind.CLIENT, Attributes.empty(), Collections.emptyList());
-        Assertions.assertEquals(expecteDecision, result.getDecision());
+    @Test
+    public void test_samplingResult_has_sampleRate_attribute() {
+
+        for (int i = 0; i < 10; i++) {
+            Sampler sampler = new DeterministicTraceSampler(i);
+            String traceID = IdGenerator.random().generateTraceId();
+            SamplingResult result = sampler.shouldSample(Context.current(), traceID, "span", SpanKind.CLIENT, Attributes.empty(), Collections.emptyList());
+
+            Assertions.assertEquals(
+                result.getAttributes(),
+                Attributes.of(AttributeKey.longKey("SampleRate"), (long) i)
+            );
+        }
     }
 
-    private static Stream<Arguments> provideStringsForIsBlank() {
-        return Stream.of(
-            Arguments.of("a5a013ab53993340b648bc38ab92318d", SamplingDecision.RECORD_AND_SAMPLE),
-            Arguments.of("f30eb8bab58b954ebc2b99a27ad23ba5", SamplingDecision.RECORD_AND_SAMPLE),
-            Arguments.of("f380ceeefeb9914f831b0294c59d454e", SamplingDecision.RECORD_AND_SAMPLE),
-            Arguments.of("0875071575a9ce47b52732b4ca64ccc9", SamplingDecision.RECORD_AND_SAMPLE),
-            Arguments.of("4d7feb838b90fb4c88a4905b39460cfa", SamplingDecision.RECORD_AND_SAMPLE),
-            Arguments.of("741de0d981866e47b2207fcb9be1c207", SamplingDecision.RECORD_AND_SAMPLE),
-            Arguments.of("eda648054e388d49a80cffaef8d182bc", SamplingDecision.RECORD_AND_SAMPLE),
-            Arguments.of("ed4089963f24634dbc91cc2b3d55407c", SamplingDecision.RECORD_AND_SAMPLE),
-            Arguments.of("e06e17e6b57fc54489e0e205f060a1e5", SamplingDecision.RECORD_AND_SAMPLE),
-            Arguments.of("d58153786958be408106f7297836229f", SamplingDecision.RECORD_AND_SAMPLE),
-            Arguments.of("5a8794bd6402bd429054fa71fb58b68c", SamplingDecision.RECORD_AND_SAMPLE),
-            Arguments.of("7f09606a8908fc49a824cf2189a7e087", SamplingDecision.DROP),
-            Arguments.of("25c9c9f1002576469999e69e02c0be7e", SamplingDecision.DROP),
-            Arguments.of("c7f818f60d780145b4355ab0603d4d0c", SamplingDecision.DROP),
-            Arguments.of("817a087bbbed1b4c96258f07d59fe006", SamplingDecision.DROP),
-            Arguments.of("46cd1af9a07eaa40b00f227dea73c3fc", SamplingDecision.DROP),
-            Arguments.of("384c70f32674c04ca2709c58fe066721", SamplingDecision.DROP),
-            Arguments.of("209e3ba9ecc648458b722ee622106a05", SamplingDecision.DROP),
-            Arguments.of("560b7b48bfd99c429bfb0d497ea260c6", SamplingDecision.DROP),
-            Arguments.of("2f3467b35730064597b4d93440cdc033", SamplingDecision.DROP)
-        );
+    @Test
+    public void test_deterministicSampler_varies_sampling_decision_based_on_trace_id() {
+        int count = 0;
+        for (int i = 0; i < 100; i++) {
+            Sampler sampler = new DeterministicTraceSampler(2);
+            String traceID = IdGenerator.random().generateTraceId();
+            SamplingResult result = sampler.shouldSample(Context.current(), traceID, "span", SpanKind.CLIENT, Attributes.empty(), Collections.emptyList());
+            if (result.getDecision() == SamplingDecision.RECORD_AND_SAMPLE) {
+                count++;
+            }
+        }
+
+        Assertions.assertTrue(count > 25 && count < 75);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Updates the DeterministicSampler to internally create and use a ParentBased sampler that uses a TraceIdRatioBased Sampler as it's root. The combination of ParentBased and RatioBased samplers ensure that root span's mark the trace as sampled / not sampled based on a 1/X sample rate, then subsequent spans within the same trace use the same sampling decision.

This PR reduces the complexity of our implementation and depends on the core samplers to better support multi-service & beeline / OTel environments.

- Resolves #196

## Short description of the changes
- Replace custom logic in DeterministicSampler with internally created Otel core ParentBasedSampler and TraceIdRatioBased sampler
- Sets the DeterministicSampler with a sample rate of 1 (always sampler) as the default sampler when configuring the OpenTelemetry SDK
- Update tests to verify behaviour, including:
- - Always on (sample rate of 1 - 1.0 ratio)
- - Always off (sample rate of 0 0.0 ratio)
- - Deterministic (sampler rate of 2 - 0.5 ratio)
- - Ensure `SampleRate` attribute is returned in SamplingDecision