### PR TITLE
Remove -all suffix from artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ smoke-tests/collector/data.json:
 	@echo "+++ Zhuzhing smoke test's Collector data.json"
 	@touch $@ && chmod o+w $@
 
-smoke-tests/apps/agent.jar: build-artifacts/honeycomb-opentelemetry-javaagent-${project_version}-all.jar
+smoke-tests/apps/agent.jar: build-artifacts/honeycomb-opentelemetry-javaagent-${project_version}.jar
 	@echo ""
 	@echo "+++ Getting the agent in place for smoking."
 	@echo ""

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -34,6 +34,8 @@ CopySpec isolateSpec() {
 tasks {
     shadowJar {
         archivesBaseName = "${artifactName}"
+        archiveClassifier.set("")
+        archiveVersion.set(project.version)
 
         dependsOn ':custom:shadowJar'
         with isolateSpec()

--- a/custom/build.gradle
+++ b/custom/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 tasks {
     shadowJar {
         archivesBaseName = "honeycomb-opentelemetry-custom"
+        archiveClassifier.set("")
+        archiveVersion.set(project.version)
 
         mergeServiceFiles()
 

--- a/examples/spring-agent-manual/build.gradle
+++ b/examples/spring-agent-manual/build.gradle
@@ -22,5 +22,5 @@ bootRun.dependsOn ':agent:shadowJar'
 
 // use local agent
 bootRun.doFirst {
-	jvmArgs("-javaagent:${rootDir}/agent/build/libs/honeycomb-opentelemetry-javaagent-${project.version}-all.jar")
+	jvmArgs("-javaagent:${rootDir}/agent/build/libs/honeycomb-opentelemetry-javaagent-${project.version}.jar")
 }

--- a/examples/spring-agent-only/build.gradle
+++ b/examples/spring-agent-only/build.gradle
@@ -19,5 +19,5 @@ bootRun.dependsOn ':agent:shadowJar'
 
 // use local agent
 bootRun.doFirst {
-	jvmArgs("-javaagent:${rootDir}/agent/build/libs/honeycomb-opentelemetry-javaagent-${project.version}-all.jar")
+	jvmArgs("-javaagent:${rootDir}/agent/build/libs/honeycomb-opentelemetry-javaagent-${project.version}.jar")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #213 

## Short description of the changes

- Since upstream OTel no longer has the `-all` suffix, remove from our artifacts where applicable. The builds creating shadow jars needed changes per [Configuring Shadow](https://imperceptiblethoughts.com/shadow/configuration/#configuring-output-name)
- Examples also dropped `-all` and the Makefile no longer looks in `-all` for smoking.

[CI Step showing old build includes `-all` jars](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-java/807/workflows/2130c44a-eed2-471d-be61-147d0fd5a68d/jobs/3038/parallel-runs/0/steps/0-107)

[CI Step showing new build has no `-all` jars](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-java/814/workflows/ab4c69b1-6bbf-4ceb-a9d9-3a03caf14d40/jobs/3073/parallel-runs/0/steps/0-107)