### PR TITLE
publish_maven needs updated directory of jars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
             - run:
                 command: |
                   shopt -s globstar
-                  cp **/build/libs/*.jar ./publish-artifacts
+                  cp **/build-artifacts/*.jar ./publish-artifacts
             - persist_to_workspace:
                 root: ./
                 paths:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- [publish_maven step in ci](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-java/821/workflows/82b49453-d6d8-4b00-8d06-311a55621329/jobs/3110/parallel-runs/0/steps/0-106) failed in [tagged release](https://github.com/honeycombio/honeycomb-opentelemetry-java/runs/4316109374)

## Short description of the changes

- When working on smoke-tests in #197 , everything got moved from /build/libs directory to a single /build-artifacts directory. This was missed in the publish_maven step of the Circle CI config so it was trying to copy from a directory that didn't exist.

