### PR TITLE
Revert "Bump junit-jupiter-api from 5.8.1 to 5.8.2 (#219)"

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -9,7 +9,7 @@ description = 'Functionality shared across components of the Honeycomb OpenTelem
 dependencies {
     testImplementation(platform('org.junit:junit-bom:5.8.1'))
     testImplementation 'org.junit.jupiter:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'junit:junit:4.13.2'
 }

--- a/custom/build.gradle
+++ b/custom/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testImplementation(platform('org.junit:junit-bom:5.8.1'))
     testImplementation 'org.junit.jupiter:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'junit:junit:4.13.2'
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
     testImplementation(platform('org.junit:junit-bom:5.8.1'))
     testImplementation 'org.junit.jupiter:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.1.0'


### PR DESCRIPTION
This reverts commit ac6e19c0cef5d2ed9b82eeed15318506bdd10f54.

<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Failling smoke test; may be unrelated and just flaky test prone to false negatives?

## Short description of the changes

-

