### PR TITLE
update smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - store_artifacts:
           path: ./smoke-tests/report.xml
       - store_artifacts:
-          path: ./smoke-tests/collector/data*.json
+          path: ./smoke-tests/collector/data-results
       - run:
           name: Extinguish the Flames
           command: make unsmoke

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,8 @@ jobs:
           path: ./smoke-tests/
       - store_artifacts:
           path: ./smoke-tests/report.xml
+      - store_artifacts:
+          path: ./smoke-tests/collector/data*.json
       - run:
           name: Extinguish the Flames
           command: make unsmoke

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,6 @@ local.properties
 .code-workspace
 
 ### temporary smoke-test files
-smoke-tests/collector/data.json
+smoke-tests/collector/data*.json
 smoke-tests/report.xml
 smoke-tests/report.html

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ local.properties
 .code-workspace
 
 ### temporary smoke-test files
-smoke-tests/collector/data*.json
+smoke-tests/collector/data.json
+smoke-tests/collector/data-results/*.json
 smoke-tests/report.xml
 smoke-tests/report.html

--- a/smoke-tests/smoke-agent-manual.bats
+++ b/smoke-tests/smoke-agent-manual.bats
@@ -11,7 +11,7 @@ setup_file() {
 }
 
 teardown_file() {
-    cp collector/data.json collector/data-agent-manual.json
+    cp collector/data.json collector/data-results/data-agent-manual.json
 	docker-compose stop app-agent-manual
 	docker-compose restart collector
 	wait_for_flush

--- a/smoke-tests/smoke-agent-manual.bats
+++ b/smoke-tests/smoke-agent-manual.bats
@@ -11,6 +11,7 @@ setup_file() {
 }
 
 teardown_file() {
+    cp collector/data.json collector/data-agent-manual.json
 	docker-compose stop app-agent-manual
 	docker-compose restart collector
 	wait_for_flush

--- a/smoke-tests/smoke-agent-only.bats
+++ b/smoke-tests/smoke-agent-only.bats
@@ -11,6 +11,7 @@ setup_file() {
 }
 
 teardown_file() {
+    cp collector/data.json collector/data-agent-only.json
 	docker-compose stop app-agent-only
 	docker-compose restart collector
 	wait_for_flush

--- a/smoke-tests/smoke-agent-only.bats
+++ b/smoke-tests/smoke-agent-only.bats
@@ -11,7 +11,7 @@ setup_file() {
 }
 
 teardown_file() {
-    cp collector/data.json collector/data-agent-only.json
+    cp collector/data.json collector/data-results/data-agent-only.json
 	docker-compose stop app-agent-only
 	docker-compose restart collector
 	wait_for_flush

--- a/smoke-tests/smoke-sdk.bats
+++ b/smoke-tests/smoke-sdk.bats
@@ -11,7 +11,7 @@ setup_file() {
 }
 
 teardown_file() {
-    cp collector/data.json collector/data-sdk.json
+    cp collector/data.json collector/data-results/data-sdk.json
 	docker-compose stop app-sdk
 	docker-compose restart collector
 	wait_for_flush

--- a/smoke-tests/smoke-sdk.bats
+++ b/smoke-tests/smoke-sdk.bats
@@ -11,6 +11,7 @@ setup_file() {
 }
 
 teardown_file() {
+    cp collector/data.json collector/data-sdk.json
 	docker-compose stop app-sdk
 	docker-compose restart collector
 	wait_for_flush

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -9,11 +9,11 @@ metrics_from_library_named() {
 }
 
 spans_received() {
-	jq ".resourceSpans[]" ./collector/data.json
+	jq ".resourceSpans[]?" ./collector/data.json
 }
 
 metrics_received() {
-	jq ".resourceMetrics[]" ./collector/data.json
+	jq ".resourceMetrics[]?" ./collector/data.json
 }
 
 # test span name


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- we still have some flaky smoke tests
- when a test fails for a legitimate reason, it's hard to tell *why* without seeing the data.json
- updates #233 

## Short description of the changes

- preserve data.json from each test in a circle artifact for later investigation
- make root `jq` lookup more resilient: the data file contains both `resourceSpans` and `resourceMetrics` on different lines, adding a `?` makes it not bark about nulls on unmatched lines

