### PR TITLE
Create the AttributeKey for SampleRate once

### DIFF
--- a/sdk/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
@@ -37,7 +37,7 @@ public class DeterministicTraceSampler implements Sampler {
     private static final int ALWAYS_SAMPLE = 1;
     private static final int NEVER_SAMPLE = 0;
 
-    private static final AttributeKey SAMPLE_RATE_ATTRIBUTE_KEY = AttributeKey.longKey("SampleRate");
+    private static final AttributeKey<Long> SAMPLE_RATE_ATTRIBUTE_KEY = AttributeKey.longKey("SampleRate");
 
     private final Sampler baseSampler;
     private final int sampleRate;

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
@@ -37,9 +37,10 @@ public class DeterministicTraceSampler implements Sampler {
     private static final int ALWAYS_SAMPLE = 1;
     private static final int NEVER_SAMPLE = 0;
 
+    private static final AttributeKey SAMPLE_RATE_ATTRIBUTE_KEY = AttributeKey.longKey("SampleRate");
+
     private final Sampler baseSampler;
     private final int sampleRate;
-    private final Attributes sampleRateAttributes;
 
     public final static String DESCRIPTION = "HoneycombDeterministicSampler";
 
@@ -60,8 +61,6 @@ public class DeterministicTraceSampler implements Sampler {
         } else {
             ratio = 1.0 / sampleRate;
         }
-
-        sampleRateAttributes = Attributes.of(AttributeKey.longKey("SampleRate"), (long) sampleRate);
         baseSampler = Sampler.traceIdRatioBased(ratio);
     }
 
@@ -82,7 +81,7 @@ public class DeterministicTraceSampler implements Sampler {
         SamplingResult result = baseSampler.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
         return SamplingResult.create(
             result.getDecision(),
-            sampleRateAttributes
+            Attributes.of(SAMPLE_RATE_ATTRIBUTE_KEY, (long) sampleRate)
         );
     }
 }

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
@@ -39,6 +39,7 @@ public class DeterministicTraceSampler implements Sampler {
 
     private final Sampler baseSampler;
     private final int sampleRate;
+    private final Attributes sampleRateAttributes;
 
     public final static String DESCRIPTION = "HoneycombDeterministicSampler";
 
@@ -59,6 +60,8 @@ public class DeterministicTraceSampler implements Sampler {
         } else {
             ratio = 1.0 / sampleRate;
         }
+
+        sampleRateAttributes = Attributes.of(AttributeKey.longKey("SampleRate"), (long) sampleRate);
         baseSampler = Sampler.traceIdRatioBased(ratio);
     }
 
@@ -79,7 +82,7 @@ public class DeterministicTraceSampler implements Sampler {
         SamplingResult result = baseSampler.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
         return SamplingResult.create(
             result.getDecision(),
-            Attributes.of(AttributeKey.longKey("SampleRate"), (long) sampleRate)
+            sampleRateAttributes
         );
     }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Object creation optimization

## Short description of the changes

Small optimization to extract the creation of the `AttributeKey` for the SampleRate into a private static final to avoid creation for each span processed.


