### PR TITLE
Bump opentelemetryJavaagent to 1.9.2 to address memory leak in reactor-netty

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It makes getting started with OpenTelemetry and Honeycomb easier!
 Latest release built with:
 
 - [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.9.1) version 1.9.1
-- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.9.1) version 1.9.1
+- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.9.2) version 1.9.2
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It makes getting started with OpenTelemetry and Honeycomb easier!
 Latest release built with:
 
 - [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.9.1) version 1.9.1
-- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.9.2) version 1.9.2
+- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.9.1) version 1.9.1
 
 ## Getting Started
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
     ext {
         versions = [
                 opentelemetry         : "1.9.1",
-                opentelemetryJavaagent: "1.9.1",
+                opentelemetryJavaagent: "1.9.2",
                 bytebuddy             : "1.10.18",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
     ext {
         versions = [
                 opentelemetry         : "1.9.1",
-                opentelemetryJavaagent: "1.9.2",
+                opentelemetryJavaagent: "1.9.1",
                 bytebuddy             : "1.10.18",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"


### PR DESCRIPTION
## Which problem is this PR solving?
Bump the version of the java-instrumentation library to 1.9.2 to address a memory and connection leak for reactor-netty

https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.9.2


