### PR TITLE
Publish snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,17 +126,17 @@ workflows:
             - build
   build:
     jobs:
-      - gradle/test:
-          <<: *matrix_executors
-          <<: *filters_always
+#      - gradle/test:
+#          <<: *matrix_executors
+#          <<: *filters_always
       - build:
           <<: *filters_always
-          requires:
-            - gradle/test
-      - smoke_test:
-          <<: *filters_always
-          requires:
-            - build
+#          requires:
+#            - gradle/test
+#      - smoke_test:
+#          <<: *filters_always
+#          requires:
+#            - build
       - publish_maven:
           <<: *filters_publish
           context: java_beeline

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,8 @@ jobs:
             - run: mkdir -p ./publish-artifacts
             - run:
                 name: "Publish Artifacts to Maven"
-                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+#                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+                command: ./gradlew publishToSonatype
             - run:
                 command: |
                   shopt -s globstar
@@ -92,12 +93,12 @@ filters_main_only: &filters_main_only
     tags:
       only: /.*/
     branches:
-      only: main
+      only: vera.snapshots
 
 filters_tags_only: &filters_tags_only
   filters:
     tags:
-      only: /^v.*/
+      only: /^test.*/
     branches:
       ignore: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,18 +39,18 @@ jobs:
       - run:
           name: Print project version
           command: make project_version -d
-      - run:
-          name: Smoke Test
-          command: make smoke -d
+#      - run:
+#          name: Smoke Test
+#          command: make smoke -d
       - store_test_results:
           path: ./smoke-tests/
       - store_artifacts:
           path: ./smoke-tests/report.xml
       - store_artifacts:
           path: ./smoke-tests/collector/data-results
-      - run:
-          name: Extinguish the Flames
-          command: make unsmoke
+#      - run:
+#          name: Extinguish the Flames
+#          command: make unsmoke
 
   publish_github:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,20 +37,17 @@ jobs:
             which bats
             bats --version
       - run:
-          name: Print project version
-          command: make project_version -d
-#      - run:
-#          name: Smoke Test
-#          command: make smoke -d
+          name: Smoke Test
+          command: make smoke -d
       - store_test_results:
           path: ./smoke-tests/
       - store_artifacts:
           path: ./smoke-tests/report.xml
       - store_artifacts:
           path: ./smoke-tests/collector/data-results
-#      - run:
-#          name: Extinguish the Flames
-#          command: make unsmoke
+      - run:
+          name: Extinguish the Flames
+          command: make unsmoke
 
   publish_github:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ jobs:
             which bats
             bats --version
       - run:
+          name: Project version?
+          command: make project_version
+      - run:
           name: Smoke Test
           command: make smoke
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             bats --version
       - run:
           name: Smoke Test
-          command: make smoke -d
+          command: make smoke
       - store_test_results:
           path: ./smoke-tests/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ jobs:
             which bats
             bats --version
       - run:
+          name: Print project version
+          command: make project_version -d
+      - run:
           name: Smoke Test
           command: make smoke -d
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,7 @@ jobs:
             - run: mkdir -p ./publish-artifacts
             - run:
                 name: "Publish Artifacts to Maven"
-#                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
-                command: ./gradlew publishToSonatype
+                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
             - run:
                 command: |
                   shopt -s globstar
@@ -93,12 +92,12 @@ filters_main_only: &filters_main_only
     tags:
       only: /.*/
     branches:
-      only: vera.snapshots
+      only: main
 
 filters_tags_only: &filters_tags_only
   filters:
     tags:
-      only: /^test.*/
+      only: /^v.*/
     branches:
       ignore: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,20 +54,20 @@ jobs:
       - image: cibuilds/github:0.13.0
     steps:
       - attach_workspace:
-          at: ~/
+          at: ./
       - run:
           name: "Publish Release on GitHub"
           command: |
             echo "about to publish to tag ${CIRCLE_TAG}"
-            ls -l ~/publish-artifacts/*
-            ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/publish-artifacts
+            ls -l ./publish-artifacts/*
+            ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./publish-artifacts
   publish_maven:
     executor: gradle/default
     steps:
       - checkout
       - gradle/with_cache:
           steps:
-            - run: mkdir -p ~/publish-artifacts
+            - run: mkdir -p ./publish-artifacts
             - run:
                 name: "Publish Artifacts to Maven"
 #                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
@@ -75,13 +75,13 @@ jobs:
             - run:
                 command: |
                   shopt -s globstar
-                  cp build-artifacts/*.jar ~/publish-artifacts
+                  cp build-artifacts/*.jar ./publish-artifacts
             - persist_to_workspace:
-                root: ~/
+                root: ./
                 paths:
                   - publish-artifacts
             - store_artifacts:
-                path: ~/publish-artifacts
+                path: ./publish-artifacts
 
 filters_always: &filters_always
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,12 +92,12 @@ filters_main_only: &filters_main_only
     tags:
       only: /.*/
     branches:
-      only: vera.snapshots
+      only: main
 
 filters_tags_only: &filters_tags_only
   filters:
     tags:
-      only: /^test.*/
+      only: /^v.*/
     branches:
       ignore: /.*/
 
@@ -133,22 +133,22 @@ workflows:
             - build
   build:
     jobs:
-#      - gradle/test:
-#          <<: *matrix_executors
-#          <<: *filters_always
+      - gradle/test:
+          <<: *matrix_executors
+          <<: *filters_always
       - build:
           <<: *filters_always
-#          requires:
-#            - gradle/test
-#      - smoke_test:
-#          <<: *filters_always
-#          requires:
-#            - build
+          requires:
+            - gradle/test
+      - smoke_test:
+          <<: *filters_always
+          requires:
+            - build
       - publish_maven:
           <<: *filters_main_only
           context: java_beeline
-#          requires:
-#            - smoke_test
+          requires:
+            - smoke_test
       - publish_github:
           <<: *filters_tags_only
           context: Honeycomb Secrets for Public Repos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,11 +37,8 @@ jobs:
             which bats
             bats --version
       - run:
-          name: Project version?
-          command: make project_version -d
-      - run:
           name: Smoke Test
-          command: make smoke
+          command: make smoke -d
       - store_test_results:
           path: ./smoke-tests/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ filters_main_only: &filters_main_only
     tags:
       only: /.*/
     branches:
-      only: main
+      only: vera.snapshots
 
 filters_tags_only: &filters_tags_only
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             bats --version
       - run:
           name: Project version?
-          command: make project_version
+          command: make project_version -d
       - run:
           name: Smoke Test
           command: make smoke

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,7 @@ jobs:
             - run: mkdir -p ./publish-artifacts
             - run:
                 name: "Publish Artifacts to Maven"
-#                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
-                command: ./gradlew publishToSonatype
+                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
             - run:
                 command: |
                   shopt -s globstar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,14 @@ filters_always: &filters_always
     tags:
       only: /.*/
 
-filters_publish: &filters_publish
+filters_main_only: &filters_main_only
+  filters:
+    tags:
+      only: /.*/
+    branches:
+      only: main
+
+filters_tags_only: &filters_tags_only
   filters:
     tags:
       only: /^v.*/
@@ -139,12 +146,12 @@ workflows:
 #          requires:
 #            - build
       - publish_maven:
-          <<: *filters_publish
+          <<: *filters_main_only
           context: java_beeline
 #          requires:
 #            - smoke_test
       - publish_github:
-          <<: *filters_publish
+          <<: *filters_tags_only
           context: Honeycomb Secrets for Public Repos
           requires:
             - publish_maven

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,20 +54,20 @@ jobs:
       - image: cibuilds/github:0.13.0
     steps:
       - attach_workspace:
-          at: ./
+          at: ~/
       - run:
           name: "Publish Release on GitHub"
           command: |
             echo "about to publish to tag ${CIRCLE_TAG}"
-            ls -l ./publish-artifacts/*
-            ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./publish-artifacts
+            ls -l ~/publish-artifacts/*
+            ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/publish-artifacts
   publish_maven:
     executor: gradle/default
     steps:
       - checkout
       - gradle/with_cache:
           steps:
-            - run: mkdir -p ./publish-artifacts
+            - run: mkdir -p ~/publish-artifacts
             - run:
                 name: "Publish Artifacts to Maven"
 #                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
@@ -75,9 +75,9 @@ jobs:
             - run:
                 command: |
                   shopt -s globstar
-                  cp build-artifacts/*.jar ./publish-artifacts
+                  cp build-artifacts/*.jar ~/publish-artifacts
             - persist_to_workspace:
-                root: ./
+                root: ~/
                 paths:
                   - publish-artifacts
             - store_artifacts:
@@ -98,7 +98,7 @@ filters_main_only: &filters_main_only
 filters_tags_only: &filters_tags_only
   filters:
     tags:
-      only: /^v.*/
+      only: /^test.*/
     branches:
       ignore: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
             - run:
                 command: |
                   shopt -s globstar
-                  cp **/build-artifacts/*.jar ./publish-artifacts
+                  cp build-artifacts/*.jar ./publish-artifacts
             - persist_to_workspace:
                 root: ./
                 paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,8 @@ jobs:
             - run: mkdir -p ./publish-artifacts
             - run:
                 name: "Publish Artifacts to Maven"
-                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+#                command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+                command: ./gradlew publishToSonatype
             - run:
                 command: |
                   shopt -s globstar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,8 @@ workflows:
       - publish_maven:
           <<: *filters_publish
           context: java_beeline
-          requires:
-            - smoke_test
+#          requires:
+#            - smoke_test
       - publish_github:
           <<: *filters_publish
           context: Honeycomb Secrets for Public Repos

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ clean:
 	rm -rf ./smoke-tests/report.*
 	./gradlew clean
 
-project_version:=$(shell ./gradlew project_version -q)
+print_project_version:=$(shell ./gradlew project_version -q)
 #: display the project's version
 project_version:
-	@echo ${project_version}
+	@echo ${print_project_version}
 
 build-artifacts:
 	mkdir -p ./build-artifacts

--- a/Makefile
+++ b/Makefile
@@ -26,25 +26,25 @@ smoke-tests/collector/data.json:
 	@echo "+++ Zhuzhing smoke test's Collector data.json"
 	@touch $@ && chmod o+w $@
 
-smoke-tests/apps/agent.jar: build-artifacts/honeycomb-opentelemetry-javaagent-$(project_version).jar
+smoke-tests/apps/agent.jar: build-artifacts/honeycomb-opentelemetry-javaagent-${project_version}.jar
 	@echo ""
 	@echo "+++ Getting the agent in place for smoking."
 	@echo ""
 	cp $< $@
 
-smoke-tests/apps/spring-agent-manual.jar: build-artifacts/spring-agent-manual-$(project_version).jar
+smoke-tests/apps/spring-agent-manual.jar: build-artifacts/spring-agent-manual-${project_version}.jar
 	@echo ""
 	@echo "+++ Getting the auto & manually instrumented app in place for smoking."
 	@echo ""
 	cp $< $@
 
-smoke-tests/apps/spring-agent-only.jar: build-artifacts/spring-agent-only-$(project_version).jar
+smoke-tests/apps/spring-agent-only.jar: build-artifacts/spring-agent-only-${project_version}.jar
 	@echo ""
 	@echo "+++ Getting the auto-instrumented app in place for smoking."
 	@echo ""
 	cp $< $@
 
-smoke-tests/apps/spring-sdk.jar: build-artifacts/spring-sdk-$(project_version).jar
+smoke-tests/apps/spring-sdk.jar: build-artifacts/spring-sdk-${project_version}.jar
 	@echo ""
 	@echo "+++ Getting the SDK manually-instrumented app in place for smoking."
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	rm -rf ./smoke-tests/report.*
 	./gradlew clean
 
-project_version:=$(shell ./gradlew project_version -q)
+project_version:=$(shell ./gradlew project_version -q | awk '{print $$1}')
 #: display the project's version
 project_version:
 	@echo ${project_version}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	rm -rf ./smoke-tests/report.*
 	./gradlew clean
 
-project_version:=$(shell grep 'project.version =' build.gradle | awk -F\" '{ print $$2 }')
+project_version:=$(shell ./gradlew properties -q | grep "version:" | awk '{print $$2}')
 #: display the project's version
 project_version:
 	@echo ${project_version}

--- a/Makefile
+++ b/Makefile
@@ -26,25 +26,25 @@ smoke-tests/collector/data.json:
 	@echo "+++ Zhuzhing smoke test's Collector data.json"
 	@touch $@ && chmod o+w $@
 
-smoke-tests/apps/agent.jar: build-artifacts/honeycomb-opentelemetry-javaagent-${project_version}.jar
+smoke-tests/apps/agent.jar: build-artifacts/honeycomb-opentelemetry-javaagent-123.jar
 	@echo ""
 	@echo "+++ Getting the agent in place for smoking."
 	@echo ""
 	cp $< $@
 
-smoke-tests/apps/spring-agent-manual.jar: build-artifacts/spring-agent-manual-${project_version}.jar
+smoke-tests/apps/spring-agent-manual.jar: build-artifacts/spring-agent-manual-123.jar
 	@echo ""
 	@echo "+++ Getting the auto & manually instrumented app in place for smoking."
 	@echo ""
 	cp $< $@
 
-smoke-tests/apps/spring-agent-only.jar: build-artifacts/spring-agent-only-${project_version}.jar
+smoke-tests/apps/spring-agent-only.jar: build-artifacts/spring-agent-only-123.jar
 	@echo ""
 	@echo "+++ Getting the auto-instrumented app in place for smoking."
 	@echo ""
 	cp $< $@
 
-smoke-tests/apps/spring-sdk.jar: build-artifacts/spring-sdk-${project_version}.jar
+smoke-tests/apps/spring-sdk.jar: build-artifacts/spring-sdk-123.jar
 	@echo ""
 	@echo "+++ Getting the SDK manually-instrumented app in place for smoking."
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ smoke-tests/collector/data.json:
 	@echo "+++ Zhuzhing smoke test's Collector data.json"
 	@touch $@ && chmod o+w $@
 
-smoke-tests/apps/agent.jar: build-artifacts/honeycomb-opentelemetry-javaagent-${project_version}.jar
+smoke-tests/apps/agent.jar: build-artifacts/honeycomb-opentelemetry-javaagent-$(project_version).jar
 	@echo ""
 	@echo "+++ Getting the agent in place for smoking."
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	rm -rf ./smoke-tests/report.*
 	./gradlew clean
 
-project_version:=$(shell ./gradlew properties -q | grep "version:" | awk '{print $$2}')
+project_version:=$(shell ./gradlew project_version -q)
 #: display the project's version
 project_version:
 	@echo ${project_version}

--- a/Makefile
+++ b/Makefile
@@ -32,19 +32,19 @@ smoke-tests/apps/agent.jar: build-artifacts/honeycomb-opentelemetry-javaagent-$(
 	@echo ""
 	cp $< $@
 
-smoke-tests/apps/spring-agent-manual.jar: build-artifacts/spring-agent-manual-123.jar
+smoke-tests/apps/spring-agent-manual.jar: build-artifacts/spring-agent-manual-$(project_version).jar
 	@echo ""
 	@echo "+++ Getting the auto & manually instrumented app in place for smoking."
 	@echo ""
 	cp $< $@
 
-smoke-tests/apps/spring-agent-only.jar: build-artifacts/spring-agent-only-123.jar
+smoke-tests/apps/spring-agent-only.jar: build-artifacts/spring-agent-only-$(project_version).jar
 	@echo ""
 	@echo "+++ Getting the auto-instrumented app in place for smoking."
 	@echo ""
 	cp $< $@
 
-smoke-tests/apps/spring-sdk.jar: build-artifacts/spring-sdk-123.jar
+smoke-tests/apps/spring-sdk.jar: build-artifacts/spring-sdk-$(project_version).jar
 	@echo ""
 	@echo "+++ Getting the SDK manually-instrumented app in place for smoking."
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	rm -rf ./smoke-tests/report.*
 	./gradlew clean
 
-project_version:=$(shell ./gradlew project_version -q | awk '{print $$1}')
+project_version:=$(shell ./gradlew properties -q | grep "version:" | awk '{print $$2}')
 #: display the project's version
 project_version:
 	@echo ${project_version}

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ smoke-tests/collector/data.json:
 	@echo "+++ Zhuzhing smoke test's Collector data.json"
 	@touch $@ && chmod o+w $@
 
-smoke-tests/apps/agent.jar: build-artifacts/honeycomb-opentelemetry-javaagent-123.jar
+smoke-tests/apps/agent.jar: build-artifacts/honeycomb-opentelemetry-javaagent-$(project_version).jar
 	@echo ""
 	@echo "+++ Getting the agent in place for smoking."
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ clean:
 	rm -rf ./smoke-tests/report.*
 	./gradlew clean
 
-print_project_version:=$(shell ./gradlew project_version -q)
+project_version:=$(shell ./gradlew project_version -q)
 #: display the project's version
 project_version:
-	@echo ${print_project_version}
+	@echo ${project_version}
 
 build-artifacts:
 	mkdir -p ./build-artifacts

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,17 @@
 # Creating a new release
 
-1. First, update the `project.version` in the root build.gradle file. Update the version in `DistroMetadata.java`. Also update the Changelog, as well as any references to the previous version in the docs.
+1. Update the `project.version` in the root build.gradle file with the new release version. Snapshot version is one patch bump ahead of the new release (e.g. if we're releasing `1.0.0` then the corresponding snapshot would be `1.0.1`)
 
-2. If the new release updates the OpenTelemetry SDK and/or agent versions, update the `Latest release built with` section in the [README](./README.md).
+2. Update the version in `DistroMetadata.java` with the new release version
 
-3. Once the above changes are merged into `main`, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off CI, which will publish a draft GitHub release, and publish to Maven.
+3. Update the Changelog
 
-4. Update Release Notes on the new draft GitHub release, and publish that.
+4. If the new release updates the OpenTelemetry SDK and/or agent versions, update the `Latest release built with` section in the [README](./README.md).
 
-5. Update public docs with the new version.
+5. Once the above changes are merged into `main`, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off CI, which will publish a draft GitHub release, and publish to Maven.
+
+6. Update Release Notes on the new draft GitHub release, and publish that.
+
+7. Update public docs with the new version.
 
 Voila!

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ allprojects {
     project.group = "io.honeycomb"
     def tag = System.getenv("CIRCLE_TAG")
     if (tag != null && tag.startsWith("test")) {
-        project.version = "0.8.1"
+        project.version = "0.8.2"
     } else {
-        project.version = "0.8.2-SNAPSHOT"
+        project.version = "0.8.3-SNAPSHOT"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@ plugins {
 allprojects {
     project.group = "io.honeycomb"
     project.version = "0.8.1"
+    def tag = System.getenv("CIRCLE_TAG")
+    println "circle tag!"
+    println tag
 }
 
 tasks.register('project_version') {

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,11 @@ plugins {
 allprojects {
     project.group = "io.honeycomb"
     def tag = System.getenv("CIRCLE_TAG")
-    if (tag != null && tag.startsWith("test")) {
-        project.version = "0.8.2"
+    if (tag != null && tag.startsWith("v")) {
+        // circle tag means we're publishing a release version
+        project.version = "0.8.1"
     } else {
-        project.version = "0.8.3-SNAPSHOT"
+        project.version = "0.8.2-SNAPSHOT"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,9 @@ allprojects {
     project.group = "io.honeycomb"
     project.version = "0.8.1"
     def tag = System.getenv("CIRCLE_TAG")
-    println "circle tag!"
-    println tag
+    if (tag != null && tag.startsWith("test")) {
+        println "huZZah!"
+    }
 }
 
 tasks.register('project_version') {

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,11 @@ plugins {
 
 allprojects {
     project.group = "io.honeycomb"
-    project.version = "0.8.1"
     def tag = System.getenv("CIRCLE_TAG")
     if (tag != null && tag.startsWith("test")) {
-        println "huZZah!"
+        project.version = "0.8.1"
+    } else {
+        project.version = "0.8.2-SNAPSHOT"
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- we want to exercise our publish pipeline more regularly than just at release time
- having snapshots in maven makes it easier to test artifacts without the need to build them locally
- closes #247 

## Short description of the changes

- release to maven on every commit to `main`!
- the publish plugin will push things to the snapshot repo if the project version ends in `SNAPSHOT`, and to the main repo otherwise
- publish job was not storing artifacts in CI -- fixed
- this adds another manual step of updating the snapshot version when updating the release version
- this is the first step in getting dev releases started, I think we can iterate in the future:
  - consolidate version number in a single place (right now it's twice in build.gradle and in DistroMetadata)
  - maybe use the circle tag as the source of truth for what's being released?
  - automate updating next snapshot version in CI?

