### PR TITLE
feat: provide more feedback to users to help configure for use in E&S

### DIFF
--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -202,10 +202,18 @@ public class EnvironmentConfiguration {
         }
 
         System.setProperty("otel.exporter.otlp.traces.endpoint", endpoint);
-        System.setProperty("otel.exporter.otlp.traces.headers",
+
+        // send dataset if legacy, otherwise no dataset
+        if (isPresent(apiKey) && isLegacyKey(apiKey)) {
+            System.setProperty("otel.exporter.otlp.traces.headers",
             String.format("%s=%s,%s=%s",
                 HONEYCOMB_TEAM_HEADER, apiKey,
                 HONEYCOMB_DATASET_HEADER, dataset));
+        } else if (isPresent(apiKey)) {
+            System.setProperty("otel.exporter.otlp.traces.headers",
+            String.format("%s=%s", HONEYCOMB_TEAM_HEADER, apiKey));
+        }
+
     }
 
     public static void enableOTLPMetrics() {

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -202,6 +202,16 @@ public class EnvironmentConfiguration {
             System.out.printf("WARN: %s%n", getErrorMessage("dataset", HONEYCOMB_DATASET));
         }
 
+        // heads up: even if dataset is set, it will be ignored
+        if (isPresent(apiKey) && !isLegacyKey(apiKey) && isPresent(dataset)) {
+            if (isPresent(serviceName)) {
+                System.out.printf("WARN: Dataset is ignored in favor of service name. Data will be sent to service name: %s%n", serviceName);
+            } else {
+                // should only get here if missing service name; above check shows "null" as service name
+                System.out.printf("WARN: Dataset is ignored in favor of service name.%n");
+            }
+        }
+
         System.setProperty("otel.exporter.otlp.traces.endpoint", endpoint);
 
         // send dataset if legacy, otherwise no dataset

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -190,7 +190,9 @@ public class EnvironmentConfiguration {
 
         // helpful to know if service name is missing
         if (!isPresent(serviceName)) {
-            System.out.printf("WARN: %s%n", getErrorMessage("service name", SERVICE_NAME));
+            System.out.printf("WARN: %s%n",
+            getErrorMessage("service name", SERVICE_NAME) +
+            " If left unset, this will show up in Honeycomb as unknown_service:java");
         }
 
         if (!isPresent(apiKey)) {

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -11,6 +11,7 @@ import java.util.Properties;
  */
 public class EnvironmentConfiguration {
 
+    // environment variable names
     public static final String HONEYCOMB_API_KEY = "HONEYCOMB_API_KEY";
     public static final String HONEYCOMB_TRACES_APIKEY = "HONEYCOMB_TRACES_APIKEY";
     public static final String HONEYCOMB_METRICS_APIKEY = "HONEYCOMB_METRICS_APIKEY";
@@ -22,11 +23,17 @@ public class EnvironmentConfiguration {
     public static final String HONEYCOMB_METRICS_DATASET = "HONEYCOMB_METRICS_DATASET";
     public static final String SERVICE_NAME = "SERVICE_NAME";
     public static final String SAMPLE_RATE = "SAMPLE_RATE";
+    public static final String HONEYCOMB_CONFIGURATION_FILE = "HONEYCOMB_CONFIG_FILE";
+
+    // default value
     public static final String DEFAULT_HONEYCOMB_ENDPOINT = "https://api.honeycomb.io:443";
+
+    // attribute key names
     public static final String SERVICE_NAME_FIELD = "service.name";
+
+    // http header names
     public static final String HONEYCOMB_TEAM_HEADER = "X-Honeycomb-Team";
     public static final String HONEYCOMB_DATASET_HEADER = "X-Honeycomb-Dataset";
-    public static final String HONEYCOMB_CONFIGURATION_FILE = "HONEYCOMB_CONFIG_FILE";
 
     private static final Properties properties = loadPropertiesFromConfigFile();
     private static final String OTEL_AGENT_CONFIG_FILE = "otel.javaagent.configuration-file";
@@ -147,6 +154,12 @@ public class EnvironmentConfiguration {
         return value != null && !value.isEmpty();
     }
 
+    public static boolean isLegacyKey(String key) {
+        // legacy key has 32 characters
+        // todo: check multi-line input
+        return key.matches("^[0-9a-fA-F]{32}$");
+    }
+
     private static String readVariable(String key, String fallback) {
         // preference order is system prop -> env var -> config file, following the agent config order:
         // https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/2fbec9331349650890620266e9c22512c9433986/docs/agent-config.md#configuring-the-agent
@@ -174,6 +187,12 @@ public class EnvironmentConfiguration {
         final String endpoint = getHoneycombTracesApiEndpoint();
         final String apiKey = getHoneycombTracesApiKey();
         final String dataset = getHoneycombTracesDataset();
+        final String serviceName = getServiceName();
+
+        // helpful to know if service name is missing
+        if (!isPresent(serviceName)) {
+            System.out.printf("WARN: %s%n", getErrorMessage("service name", SERVICE_NAME));
+        }
 
         if (!isPresent(apiKey)) {
             System.out.printf("WARN: %s%n", getErrorMessage("API key", HONEYCOMB_API_KEY));

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -213,7 +213,7 @@ public class EnvironmentConfiguration {
             if (isLegacyKey(apiKey)) {
                 // if the key is legacy, add dataset to the header
                 if (isPresent(dataset)) {
-                    header += String.format("%s=%s", HONEYCOMB_DATASET_HEADER, dataset);
+                    header += String.format(",%s=%s", HONEYCOMB_DATASET_HEADER, dataset);
                 } else {
                     // if legacy key and missing dataset, warn on missing dataset
                     System.out.printf("WARN: %s%n", getErrorMessage("dataset", HONEYCOMB_DATASET));

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -156,8 +156,7 @@ public class EnvironmentConfiguration {
 
     public static boolean isLegacyKey(String key) {
         // legacy key has 32 characters
-        // todo: check multi-line input
-        return key.matches("^[0-9a-fA-F]{32}$");
+        return key.length() == 32;
     }
 
     private static String readVariable(String key, String fallback) {

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -131,6 +131,16 @@ public class EnvironmentConfigurationTest {
     }
 
     @Test
+    public void test_enableOtlpTraces_sets_system_properties_for_non_legacy_key() {
+        System.setProperty("honeycomb.api.key", "specialenvkey");
+        System.setProperty("honeycomb.dataset", "my-dataset");
+
+        EnvironmentConfiguration.enableOTLPTraces();
+        Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.traces.endpoint"));
+        Assertions.assertEquals("X-Honeycomb-Team=specialenvkey", System.getProperty("otel.exporter.otlp.traces.headers"));
+    }
+
+    @Test
     public void test_enableOtlpMetrics_sets_system_properties() {
         System.setProperty("honeycomb.api.key", "my-key");
         System.setProperty("honeycomb.metrics.dataset", "my-dataset");

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -121,13 +121,13 @@ public class EnvironmentConfigurationTest {
     }
 
     @Test
-    public void test_enableOtlpTraces_sets_system_properties() {
-        System.setProperty("honeycomb.api.key", "my-key");
+    public void test_enableOtlpTraces_sets_system_properties_for_legacy_key() {
+        System.setProperty("honeycomb.api.key", "11111111111111111111111111111111");
         System.setProperty("honeycomb.dataset", "my-dataset");
 
         EnvironmentConfiguration.enableOTLPTraces();
         Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.traces.endpoint"));
-        Assertions.assertEquals("X-Honeycomb-Team=my-key,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.traces.headers"));
+        Assertions.assertEquals("X-Honeycomb-Team=11111111111111111111111111111111,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.traces.headers"));
     }
 
     @Test

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -151,6 +151,18 @@ public class EnvironmentConfigurationTest {
         Assertions.assertEquals("X-Honeycomb-Team=my-key,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
     }
 
+    // make sure OtlpTraces logic doesn't bleed into metrics; dataset still needed
+    @Test
+    public void test_enableOtlpMetrics_sets_system_properties_for_legacy_key() {
+        System.setProperty("honeycomb.api.key", "11111111111111111111111111111111");
+        System.setProperty("honeycomb.metrics.dataset", "my-dataset");
+
+        EnvironmentConfiguration.enableOTLPMetrics();
+        Assertions.assertEquals("otlp", System.getProperty("otel.metrics.exporter"));
+        Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.metrics.endpoint"));
+        Assertions.assertEquals("X-Honeycomb-Team=11111111111111111111111111111111,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
+    }
+
     @Test
     public void test_enableOtlpMetrics_without_dataset_does_not_enable_metrics() {
         System.setProperty("honeycomb.api.key", "my-key");

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -305,6 +305,16 @@ public final class OpenTelemetryConfiguration {
                     EnvironmentConfiguration.HONEYCOMB_API_KEY));
             }
 
+            // heads up: even if dataset is set, it will be ignored
+            if (isPresent(tracesApiKey) && !isLegacyKey(tracesApiKey) && isPresent(tracesDataset)) {
+                if (isPresent(serviceName)) {
+                    System.out.printf("WARN: Dataset is ignored in favor of service name. Data will be sent to service name: %s%n", serviceName);
+                } else {
+                    // should only get here if missing service name; above check shows "null" as service name
+                    System.out.printf("WARN: Dataset is ignored in favor of service name.%n");
+                }
+            }
+
             // only warn on missing dataset if provided key is legacy or if no key is provided
             if (!isPresent(tracesDataset)) {
                 if ((isPresent(tracesApiKey) && isLegacyKey(tracesApiKey)) || (!isPresent(tracesApiKey))) {

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -293,6 +293,11 @@ public final class OpenTelemetryConfiguration {
 
             Logger logger = Logger.getLogger(OpenTelemetryConfiguration.class.getName());
 
+            // helpful to know if service name is missing
+            if (!isPresent(serviceName)) {
+                logger.warning(EnvironmentConfiguration.getErrorMessage("service name",
+                    EnvironmentConfiguration.SERVICE_NAME) + " If left unset, this will show up in Honeycomb as unknown_service:java");
+            }
             if (!isPresent(tracesApiKey)) {
                 logger.warning(EnvironmentConfiguration.getErrorMessage("API key",
                     EnvironmentConfiguration.HONEYCOMB_API_KEY));


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #256 

## Short description of the changes

- Details are captured in the issue. In E&S, dataset is no longer required but service name is. Warnings have been added to help guide changes that may be needed for missing properties.
- Note: no changes to metrics

Logging output when missing all variables:

```shell
WARN: Missing service name. Specify either SERVICE_NAME environment variable or service.name system property. If left unset, this will show up in Honeycomb as unknown_service:java
WARN: Missing API key. Specify either HONEYCOMB_API_KEY environment variable or honeycomb.api.key system property.
```

Logging output, using all variables (non-legacy key, service name set to jamie_service):

```shell
WARN: Dataset is ignored in favor of service name. Data will be sent to service name: jamie_service
```

Logging output with only non-legacy api key set:

```shell
WARN: Missing service name. Specify either SERVICE_NAME environment variable or service.name system property. If left unset, this will show up in Honeycomb as unknown_service:java
WARN: Dataset is ignored in favor of service name.
```

Logging output with legacy api key and service name set, missing dataset:

```shell
WARN: Missing dataset. Specify either HONEYCOMB_DATASET environment variable or honeycomb.dataset system property.

```