### PR TITLE
Prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # honeycomb-opentelemetry-java changelog
 
+## [0.9.0] - 2022-02-09
+
+### Enhancements
+
+- Provide more feedback to users to help configure for use in E&S (#255) | [@JamieDanielson](https://github.com/JamieDanielson)
+
+### Maintenance
+
+- Publish snapshots (#248) | [@vreynolds](https://github.com/vreynolds)
+
 ## [0.8.1] - 2022-01-11
 
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ allprojects {
     def tag = System.getenv("CIRCLE_TAG")
     if (tag != null && tag.startsWith("v")) {
         // circle tag means we're publishing a release version
-        project.version = "0.8.1"
+        project.version = "0.9.0"
     } else {
-        project.version = "0.8.2-SNAPSHOT"
+        project.version = "0.9.1-SNAPSHOT"
     }
 }
 

--- a/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
@@ -18,7 +18,7 @@ public class DistroMetadata {
      * with the version number and read it, but that isn't possible from the
      * Java agent.
      */
-    public static final String VERSION_VALUE = "0.8.1";
+    public static final String VERSION_VALUE = "0.9.0";
     public static final String RUNTIME_VERSION_FIELD = "honeycomb.distro.runtime_version";
     public static final String RUNTIME_VERSION_VALUE = System.getProperty("java.runtime.version");
 


### PR DESCRIPTION
## Which problem is this PR solving?

- The lack of a v0.9.0 release in the world.

## Short description of the changes

- Updated versions and changelog.

