### PR TITLE
fix: Use shortened environment variable for honeycomb config file

### DIFF
--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -23,7 +23,7 @@ public class EnvironmentConfiguration {
     public static final String HONEYCOMB_METRICS_DATASET = "HONEYCOMB_METRICS_DATASET";
     public static final String SERVICE_NAME = "SERVICE_NAME";
     public static final String SAMPLE_RATE = "SAMPLE_RATE";
-    public static final String HONEYCOMB_CONFIGURATION_FILE = "HONEYCOMB_CONFIG_FILE";
+    public static final String HONEYCOMB_CONFIG_FILE = "HONEYCOMB_CONFIG_FILE";
 
     // default value
     public static final String DEFAULT_HONEYCOMB_ENDPOINT = "https://api.honeycomb.io:443";
@@ -139,6 +139,15 @@ public class EnvironmentConfiguration {
     }
 
     /**
+     * Read the path to the configuration file.
+     *
+     * @return honeycomb.config.file system property or HONEYCOMB_CONFIG_FILE environment variable
+     */
+    public static String getHoneycombConfigFile() {
+        return readVariable(HONEYCOMB_CONFIG_FILE, null);
+    }
+
+    /**
      * Get a friendly error message for missing variable.
      *
      * @param humanKey human-friendly variable description
@@ -245,9 +254,9 @@ public class EnvironmentConfiguration {
     static Properties loadPropertiesFromConfigFile() {
         // check system property then env var for properties file path
         // we can't use readVariable here because it uses properties
-        String path = System.getProperty(HONEYCOMB_CONFIGURATION_FILE);
+        String path = System.getProperty(getPropertyName(HONEYCOMB_CONFIG_FILE));
         if (!isPresent(path)) {
-            path = System.getenv(HONEYCOMB_CONFIGURATION_FILE);
+            path = System.getenv(HONEYCOMB_CONFIG_FILE);
         }
 
         Properties properties = new Properties();

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -245,7 +245,7 @@ public class EnvironmentConfiguration {
     static Properties loadPropertiesFromConfigFile() {
         // check system property then env var for properties file path
         // we can't use readVariable here because it uses properties
-        String path = System.getProperty(getPropertyName(HONEYCOMB_CONFIGURATION_FILE));
+        String path = System.getProperty(HONEYCOMB_CONFIGURATION_FILE);
         if (!isPresent(path)) {
             path = System.getenv(HONEYCOMB_CONFIGURATION_FILE);
         }

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -121,6 +121,12 @@ public class EnvironmentConfigurationTest {
     }
 
     @Test
+    public void test_config_file_path() {
+        System.setProperty("honeycomb.config.file", "./src/app.properties");
+        Assertions.assertEquals("./src/app.properties", EnvironmentConfiguration.getHoneycombConfigFile());
+    }
+
+    @Test
     public void test_enableOtlpTraces_sets_system_properties_for_legacy_key() {
         System.setProperty("honeycomb.api.key", "11111111111111111111111111111111");
         System.setProperty("honeycomb.dataset", "my-dataset");

--- a/examples/spring-agent-manual/src/main/resources/application.properties
+++ b/examples/spring-agent-manual/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 server.port=5000
+honeycomb.api.key=my-api-key
+honeycomb.traces.dataset=my-traces
+service.name=spring-agent-manual

--- a/examples/spring-agent-only/src/main/resources/application.properties
+++ b/examples/spring-agent-only/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 server.port=5002
+honeycomb.api.key=my-api-key
+honeycomb.traces.dataset=my-traces
+service.name=spring-agent-only

--- a/examples/spring-sdk/src/main/resources/application.properties
+++ b/examples/spring-sdk/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 server.port=5001
+honeycomb.api.key=my-api-key
+honeycomb.traces.dataset=my-traces
+service.name=spring-sdk


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- The property to specify a path to a config file is `honeycomb.config.file`, but the environment variable was actually `HONEYCOMB_CONFIGURATION_FILE`... so `HONEYCOMB_CONFIG_FILE` didn't work. Since our docs reference using the shortened version, I think that's what we want here.

## Short description of the changes

- Changes environment variable to `HONEYCOMB_CONFIG_FILE`
- Adds test to check environment variable against system property for config file
- Adds example properties to the example apps

