### PR TITLE
resolve deprecations from upstream

### DIFF
--- a/custom/src/main/java/io/honeycomb/opentelemetry/HoneycombAutoConfigurationCustomizerProvider.java
+++ b/custom/src/main/java/io/honeycomb/opentelemetry/HoneycombAutoConfigurationCustomizerProvider.java
@@ -3,17 +3,23 @@ package io.honeycomb.opentelemetry;
 import io.honeycomb.opentelemetry.sdk.trace.samplers.DeterministicTraceSampler;
 import io.honeycomb.opentelemetry.sdk.trace.spanprocessors.BaggageSpanProcessor;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 
 /**
- * Honeycomb implementation of {@link SdkTracerProviderConfigurer} SPI.
+ * Honeycomb implementation of {@link AutoConfigurationCustomizerProvider} SPI.
  *
  * This configurer adds a trace sampler and a span processor to the OpenTelemetry auto-instrumentation.
  */
-public class HoneycombSdkTracerProviderConfigurer implements SdkTracerProviderConfigurer {
+public class HoneycombAutoConfigurationCustomizerProvider implements AutoConfigurationCustomizerProvider {
     @Override
-    public void configure(SdkTracerProviderBuilder tracerProvider, ConfigProperties config) {
+    public void customize(AutoConfigurationCustomizer autoConfiguration) {
+        autoConfiguration.addTracerProviderCustomizer(this::configureSdkTracerProvider);
+    }
+
+
+    private SdkTracerProviderBuilder configureSdkTracerProvider(SdkTracerProviderBuilder tracerProvider, ConfigProperties config) {
         int sampleRate;
         try {
             sampleRate = EnvironmentConfiguration.getSampleRate();
@@ -22,7 +28,7 @@ public class HoneycombSdkTracerProviderConfigurer implements SdkTracerProviderCo
             sampleRate = 1;
         }
 
-        tracerProvider
+        return tracerProvider
             .setSampler(new DeterministicTraceSampler(sampleRate))
             .addSpanProcessor(new BaggageSpanProcessor());
     }

--- a/custom/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
+++ b/custom/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
@@ -1,0 +1,1 @@
+io.honeycomb.opentelemetry.HoneycombAutoConfigurationCustomizerProvider

--- a/custom/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer
+++ b/custom/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer
@@ -1,1 +1,0 @@
-io.honeycomb.opentelemetry.HoneycombSdkTracerProviderConfigurer

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -346,7 +346,7 @@ public final class OpenTelemetryConfiguration {
             this.additionalSpanProcessors.forEach(tracerProviderBuilder::addSpanProcessor);
 
             if (this.enableDebug) {
-                tracerProviderBuilder.addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()));
+                tracerProviderBuilder.addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()));
             }
             tracerProviderBuilder.addSpanProcessor(BatchSpanProcessor.builder(exporter).build());
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Update use of upstream OTel Java interfaces that are deprecated and will disappear at some point in the future.

## Short description of the changes

- get a LoggingSpanExporter via create()

> The constructor LoggingSpanExporter() is deprecated.
> io.opentelemetry.exporter.logging.LoggingSpanExporter.LoggingSpanExporter()
> Deprecated Use create().

OK.

- change our autoconfig via SPI over to the new way

> io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer
> Deprecated Use AutoConfigurationCustomizer.addTracerProviderCustomizer(BiFunction).

This dep notice was not super clear on remediation advice. The changes in this PR are based on [the update](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5574/files) to the otel-java-instrumentation's own demo distribution to address the deprecation. The autoconfiguration customizer was introduced to otel-java [1.11.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.11.0) via [#4004](https://github.com/open-telemetry/opentelemetry-java/pull/4004).