### PR TITLE
Adds support for SDK to set OTLP protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,16 @@ smoke-agent-only: smoke-tests/apps/spring-agent-only.jar smoke-tests/apps/agent.
 smoke-agent-manual: smoke-tests/apps/agent.jar smoke-tests/apps/spring-agent-manual.jar smoke-tests/collector/data.json
 	cd smoke-tests && bats ./smoke-agent-manual.bats --report-formatter junit --output ./
 
-smoke-sdk: smoke-tests/apps/agent.jar smoke-tests/apps/spring-sdk.jar smoke-tests/collector/data.json
-	cd smoke-tests && bats ./smoke-sdk.bats --report-formatter junit --output ./
+.PHONY: smoke-sdk
+smoke-sdk: smoke-sdk-grpc smoke-sdk-http
+
+.PHONY: smoke-sdk-grpc
+smoke-sdk-grpc: smoke-tests/apps/agent.jar smoke-tests/apps/spring-sdk.jar smoke-tests/collector/data.json
+	cd smoke-tests && PROTO=grpc bats ./smoke-sdk.bats --report-formatter junit --output ./
+
+.PHONY: smoke-sdk-http
+smoke-sdk-http: smoke-tests/apps/agent.jar smoke-tests/apps/spring-sdk.jar smoke-tests/collector/data.json
+	cd smoke-tests && PROTO=http bats ./smoke-sdk.bats --report-formatter junit --output ./
 
 smoke: smoke-tests/apps/spring-sdk.jar smoke-tests/apps/spring-agent-manual.jar smoke-tests/apps/spring-agent-only.jar smoke-tests/apps/agent.jar smoke-tests/collector/data.json
 	@echo ""
@@ -75,7 +83,14 @@ resmoke-agent-only: unsmoke smoke-agent-only
 
 resmoke-agent-manual: unsmoke smoke-agent-manual
 
+.PHONY: resmoke-sdk
 resmoke-sdk: unsmoke smoke-sdk
+
+.PHONY: resmoke-sdk-grpc
+resmoke-sdk-grpc: unsmoke smoke-sdk-grpc
+
+.PHONY: resmoke-sdk-http
+resmoke-sdk-http: unsmoke smoke-sdk-http
 
 resmoke: unsmoke smoke
 

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,11 @@ smoke-sdk: smoke-sdk-grpc smoke-sdk-http
 
 .PHONY: smoke-sdk-grpc
 smoke-sdk-grpc: smoke-tests/apps/agent.jar smoke-tests/apps/spring-sdk.jar smoke-tests/collector/data.json
-	cd smoke-tests && PROTO=grpc bats ./smoke-sdk.bats --report-formatter junit --output ./
+	cd smoke-tests && bats ./smoke-sdk-grpc.bats --report-formatter junit --output ./
 
 .PHONY: smoke-sdk-http
 smoke-sdk-http: smoke-tests/apps/agent.jar smoke-tests/apps/spring-sdk.jar smoke-tests/collector/data.json
-	cd smoke-tests && PROTO=http bats ./smoke-sdk.bats --report-formatter junit --output ./
+	cd smoke-tests && bats ./smoke-sdk-http.bats --report-formatter junit --output ./
 
 smoke: smoke-tests/apps/spring-sdk.jar smoke-tests/apps/spring-agent-manual.jar smoke-tests/apps/spring-agent-only.jar smoke-tests/apps/agent.jar smoke-tests/collector/data.json
 	@echo ""

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -40,9 +40,9 @@ public class EnvironmentConfiguration {
     private static final Properties properties = loadPropertiesFromConfigFile();
     private static final String OTEL_AGENT_CONFIG_FILE = "otel.javaagent.configuration-file";
 
-    // OTLP protocols
-    public static final String OTLP_GRPC_PROTOBUF = "grpc";
-    public static final String OTLP_HTTP_PROTOBUF = "http/protobuf";
+    // OTLP exporter protocols
+    public static final String OTLP_PROTOCOL_GRPC = "grpc";
+    public static final String OTLP_PROTOCOL_HTTP_PROTOBUF = "http/protobuf";
 
     /**
      * Reads the Honeycomb API key.
@@ -150,7 +150,7 @@ public class EnvironmentConfiguration {
     * @return otel.exporter.otlp.protocol or OTEL_EXPORTER_OTLP_PROTOCOL environment variable.
     */
     public static String getOtelExporterOtlpProtocol() {
-        return readVariable(OTEL_EXPORTER_OTLP_PROTOCOL, OTLP_GRPC_PROTOBUF);
+        return readVariable(OTEL_EXPORTER_OTLP_PROTOCOL, OTLP_PROTOCOL_GRPC);
     }
 
     /**

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -24,6 +24,7 @@ public class EnvironmentConfiguration {
     public static final String SERVICE_NAME = "SERVICE_NAME";
     public static final String SAMPLE_RATE = "SAMPLE_RATE";
     public static final String HONEYCOMB_CONFIGURATION_FILE = "HONEYCOMB_CONFIG_FILE";
+    public static final String OTEL_EXPORTER_OTLP_PROTOCOL = "OTEL_EXPORTER_OTLP_PROTOCOL";
 
     // default value
     public static final String DEFAULT_HONEYCOMB_ENDPOINT = "https://api.honeycomb.io:443";
@@ -136,6 +137,15 @@ public class EnvironmentConfiguration {
     public static int getSampleRate() throws NumberFormatException {
         final String sampleRate = readVariable(SAMPLE_RATE, "1");
         return Integer.parseInt(sampleRate);
+    }
+
+    /**
+    * Read the OpenTelemetry exporter OTLP protocol. Default is grpc/protobuf.
+    *
+    * @return otel.exporter.otlp.protocol or OTEL_EXPORTER_OTLP_PROTOCOL environment variable.
+    */
+    public static String getOtelExporterOTLPProtocol() {
+        return readVariable(OTEL_EXPORTER_OTLP_PROTOCOL, "grpc/protobuf");
     }
 
     /**

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -24,7 +24,6 @@ public class EnvironmentConfiguration {
     public static final String SERVICE_NAME = "SERVICE_NAME";
     public static final String SAMPLE_RATE = "SAMPLE_RATE";
     public static final String HONEYCOMB_CONFIGURATION_FILE = "HONEYCOMB_CONFIG_FILE";
-    public static final String OTEL_EXPORTER_OTLP_PROTOCOL = "OTEL_EXPORTER_OTLP_PROTOCOL";
 
     // default value
     public static final String DEFAULT_HONEYCOMB_ENDPOINT = "https://api.honeycomb.io:443";
@@ -41,8 +40,9 @@ public class EnvironmentConfiguration {
     private static final String OTEL_AGENT_CONFIG_FILE = "otel.javaagent.configuration-file";
 
     // OTLP exporter protocols
-    public static final String OTLP_PROTOCOL_GRPC = "grpc";
-    public static final String OTLP_PROTOCOL_HTTP_PROTOBUF = "http/protobuf";
+    public static final String OTEL_EXPORTER_OTLP_PROTOCOL = "OTEL_EXPORTER_OTLP_PROTOCOL";
+    public static final String OTEL_EXPORTER_OTLP_PROTOCOL_GRPC = "grpc";
+    public static final String OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF = "http/protobuf";
 
     /**
      * Reads the Honeycomb API key.
@@ -150,7 +150,7 @@ public class EnvironmentConfiguration {
     * @return otel.exporter.otlp.protocol or OTEL_EXPORTER_OTLP_PROTOCOL environment variable.
     */
     public static String getOtelExporterOtlpProtocol() {
-        return readVariable(OTEL_EXPORTER_OTLP_PROTOCOL, OTLP_PROTOCOL_GRPC);
+        return readVariable(OTEL_EXPORTER_OTLP_PROTOCOL, OTEL_EXPORTER_OTLP_PROTOCOL_GRPC);
     }
 
     /**

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -39,6 +39,10 @@ public class EnvironmentConfiguration {
     private static final Properties properties = loadPropertiesFromConfigFile();
     private static final String OTEL_AGENT_CONFIG_FILE = "otel.javaagent.configuration-file";
 
+    // OTLP protocols
+    public static final String OTLP_GRPC_PROTOBUF = "grpc/protobuf";
+    public static final String OTLP_HTTP_PROTOBUF = "http/protobuf";
+
     /**
      * Reads the Honeycomb API key.
      *
@@ -145,7 +149,7 @@ public class EnvironmentConfiguration {
     * @return otel.exporter.otlp.protocol or OTEL_EXPORTER_OTLP_PROTOCOL environment variable.
     */
     public static String getOtelExporterOTLPProtocol() {
-        return readVariable(OTEL_EXPORTER_OTLP_PROTOCOL, "grpc/protobuf");
+        return readVariable(OTEL_EXPORTER_OTLP_PROTOCOL, OTLP_GRPC_PROTOBUF);
     }
 
     /**

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -144,7 +144,7 @@ public class EnvironmentConfiguration {
     }
 
     /**
-    * Read the OpenTelemetry exporter OTLP protocol. Default is grpc/protobuf.
+    * Read the OpenTelemetry exporter OTLP protocol.
     *
     * @return otel.exporter.otlp.protocol or OTEL_EXPORTER_OTLP_PROTOCOL environment variable.
     */

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -148,7 +148,7 @@ public class EnvironmentConfiguration {
     *
     * @return otel.exporter.otlp.protocol or OTEL_EXPORTER_OTLP_PROTOCOL environment variable.
     */
-    public static String getOtelExporterOTLPProtocol() {
+    public static String getOtelExporterOtlpProtocol() {
         return readVariable(OTEL_EXPORTER_OTLP_PROTOCOL, OTLP_GRPC_PROTOBUF);
     }
 

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -40,7 +40,7 @@ public class EnvironmentConfiguration {
     private static final String OTEL_AGENT_CONFIG_FILE = "otel.javaagent.configuration-file";
 
     // OTLP protocols
-    public static final String OTLP_GRPC_PROTOBUF = "grpc/protobuf";
+    public static final String OTLP_GRPC_PROTOBUF = "grpc";
     public static final String OTLP_HTTP_PROTOBUF = "http/protobuf";
 
     /**

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -27,7 +27,6 @@ public class EnvironmentConfiguration {
 
     // default value
     public static final String DEFAULT_HONEYCOMB_ENDPOINT = "https://api.honeycomb.io:443";
-    public static final String OTLP_HTTP_TRACES_PATH = "/v1/traces";
 
     // attribute key names
     public static final String SERVICE_NAME_FIELD = "service.name";
@@ -43,6 +42,7 @@ public class EnvironmentConfiguration {
     public static final String OTEL_EXPORTER_OTLP_PROTOCOL = "OTEL_EXPORTER_OTLP_PROTOCOL";
     public static final String OTEL_EXPORTER_OTLP_PROTOCOL_GRPC = "grpc";
     public static final String OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF = "http/protobuf";
+    public static final String OTEL_EXPORTER_OTLP_HTTP_TRACES_PATH = "/v1/traces";
 
     /**
      * Reads the Honeycomb API key.

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -28,6 +28,7 @@ public class EnvironmentConfiguration {
 
     // default value
     public static final String DEFAULT_HONEYCOMB_ENDPOINT = "https://api.honeycomb.io:443";
+    public static final String OTLP_HTTP_TRACES_PATH = "/v1/traces";
 
     // attribute key names
     public static final String SERVICE_NAME_FIELD = "service.name";

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -13,6 +13,7 @@ public class EnvironmentConfigurationTest {
     @BeforeEach
     public void setup() {
         System.setProperty("sample.rate", "");
+        System.setProperty("otel.exporter.otlp.protocol", "");
         System.setProperty("service.name", "");
         System.setProperty("honeycomb.api.endpoint", "");
         System.setProperty("honeycomb.traces.endpoint", "");
@@ -35,6 +36,17 @@ public class EnvironmentConfigurationTest {
     public void test_can_set_sample_rate() {
         System.setProperty("sample.rate", "10");
         Assertions.assertEquals(10, EnvironmentConfiguration.getSampleRate());
+    }
+
+    @Test
+    public void test_dafault_otel_exporter_otlp_proto() {
+        Assertions.assertEquals("grpc/protobuf", EnvironmentConfiguration.getOtelExporterOTLPProtocol());
+    }
+
+    @Test
+    public void test_can_set_otel_exporter_otlp_proto() {
+        System.setProperty("otel.exporter.otlp.protocol", "http/protobuf");
+        Assertions.assertEquals("http/protobuf", EnvironmentConfiguration.getOtelExporterOTLPProtocol());
     }
 
     @Test

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -40,7 +40,7 @@ public class EnvironmentConfigurationTest {
 
     @Test
     public void test_dafault_otel_exporter_otlp_proto() {
-        Assertions.assertEquals("grpc/protobuf", EnvironmentConfiguration.getOtelExporterOTLPProtocol());
+        Assertions.assertEquals("grpc", EnvironmentConfiguration.getOtelExporterOTLPProtocol());
     }
 
     @Test

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -40,13 +40,13 @@ public class EnvironmentConfigurationTest {
 
     @Test
     public void test_dafault_otel_exporter_otlp_proto() {
-        Assertions.assertEquals("grpc", EnvironmentConfiguration.getOtelExporterOTLPProtocol());
+        Assertions.assertEquals("grpc", EnvironmentConfiguration.getOtelExporterOtlpProtocol());
     }
 
     @Test
     public void test_can_set_otel_exporter_otlp_proto() {
         System.setProperty("otel.exporter.otlp.protocol", "http/protobuf");
-        Assertions.assertEquals("http/protobuf", EnvironmentConfiguration.getOtelExporterOTLPProtocol());
+        Assertions.assertEquals("http/protobuf", EnvironmentConfiguration.getOtelExporterOtlpProtocol());
     }
 
     @Test

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
     implementation "io.opentelemetry:opentelemetry-exporter-logging:${versions.opentelemetry}"
     implementation "io.opentelemetry:opentelemetry-exporter-otlp:${versions.opentelemetry}"
+    implementation "io.opentelemetry:opentelemetry-exporter-otlp-http-trace:${versions.opentelemetry}"
     implementation "io.opentelemetry:opentelemetry-sdk-extension-resources:${versions.opentelemetry}"
 
     implementation 'io.grpc:grpc-netty-shaded:1.43.1'

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -13,6 +13,8 @@ import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.sdk.extension.resources.OsResource;
@@ -53,6 +55,7 @@ public final class OpenTelemetryConfiguration {
         private String tracesDataset;
         private String tracesEndpoint;
         private String serviceName;
+        private String otlpProtocol = EnvironmentConfiguration.getOtelExporterOTLPProtocol();
 
         private Builder() {}
 
@@ -259,6 +262,19 @@ public final class OpenTelemetryConfiguration {
         }
 
         /**
+         * Sets the OTLP procotol used to export trace spans.
+         * Can be to either 'grpc/protobuf' or 'http/protobuf'.
+         * Default is grpc/protobuf.
+         *
+         * @param protocol The protocol to use to export spans with
+         * @return Builder
+         */
+        public Builder setOtlpProtocol(String protocol) {
+            this.otlpProtocol = protocol;
+            return this;
+        }
+
+        /**
          * Returns a new {@link OpenTelemetry} built with the configuration of this {@link
          * Builder} and registers it as the global {@link
          * io.opentelemetry.api.OpenTelemetry}. An exception will be thrown if this method is attempted to
@@ -310,8 +326,47 @@ public final class OpenTelemetryConfiguration {
                 }
             }
 
-            OtlpGrpcSpanExporterBuilder builder = OtlpGrpcSpanExporter.builder();
+            SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder()
+                .setSampler(sampler);
+            this.additionalSpanProcessors.forEach(tracerProviderBuilder::addSpanProcessor);
 
+            if (this.enableDebug) {
+                tracerProviderBuilder.addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()));
+            }
+            SpanExporter spanExporter = getSpanExporter(logger);
+            tracerProviderBuilder.addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build());
+
+            DistroMetadata.getMetadata().forEach(resourceAttributes::put);
+            if (StringUtils.isNotEmpty(serviceName)) {
+                resourceAttributes.put(EnvironmentConfiguration.SERVICE_NAME_FIELD, serviceName);
+            }
+            tracerProviderBuilder.setResource(
+                Resource.getDefault()
+                    .merge(OsResource.get())
+                    .merge(ProcessRuntimeResource.get())
+                    .merge(Resource.create(resourceAttributes.build())));
+
+            if (propagators == null) {
+                propagators = ContextPropagators.create(
+                    TextMapPropagator.composite(
+                        W3CTraceContextPropagator.getInstance(),
+                        W3CBaggagePropagator.getInstance()));
+            }
+
+            return OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProviderBuilder.build())
+                .setPropagators(propagators)
+                .build();
+        }
+
+        private SpanExporter getSpanExporter(Logger logger) {
+            return otlpProtocol == EnvironmentConfiguration.OTLP_GRPC_PROTOBUF ?
+                createHttpSpanExporter(logger) :
+                createGrpcSpanExporter(logger);
+        }
+
+        private SpanExporter createGrpcSpanExporter(Logger logger) {
+            OtlpGrpcSpanExporterBuilder builder = OtlpGrpcSpanExporter.builder();
             if (tracesEndpoint != null) {
                 builder.setEndpoint(tracesEndpoint);
             } else {
@@ -339,38 +394,39 @@ public final class OpenTelemetryConfiguration {
                     EnvironmentConfiguration.HONEYCOMB_API_KEY));
             }
 
-            SpanExporter exporter = builder.build();
+            return builder.build();
+        }
 
-            SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder()
-                .setSampler(sampler);
-            this.additionalSpanProcessors.forEach(tracerProviderBuilder::addSpanProcessor);
-
-            if (this.enableDebug) {
-                tracerProviderBuilder.addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()));
-            }
-            tracerProviderBuilder.addSpanProcessor(BatchSpanProcessor.builder(exporter).build());
-
-            DistroMetadata.getMetadata().forEach(resourceAttributes::put);
-            if (StringUtils.isNotEmpty(serviceName)) {
-                resourceAttributes.put(EnvironmentConfiguration.SERVICE_NAME_FIELD, serviceName);
-            }
-            tracerProviderBuilder.setResource(
-                Resource.getDefault()
-                    .merge(OsResource.get())
-                    .merge(ProcessRuntimeResource.get())
-                    .merge(Resource.create(resourceAttributes.build())));
-
-            if (propagators == null) {
-                propagators = ContextPropagators.create(
-                    TextMapPropagator.composite(
-                        W3CTraceContextPropagator.getInstance(),
-                        W3CBaggagePropagator.getInstance()));
+        private SpanExporter createHttpSpanExporter(Logger logger) {
+            OtlpHttpSpanExporterBuilder builder = OtlpHttpSpanExporter.builder();
+            if (tracesEndpoint != null) {
+                builder.setEndpoint(tracesEndpoint);
+            } else {
+                builder.setEndpoint(EnvironmentConfiguration.DEFAULT_HONEYCOMB_ENDPOINT);
             }
 
-            return OpenTelemetrySdk.builder()
-                .setTracerProvider(tracerProviderBuilder.build())
-                .setPropagators(propagators)
-                .build();
+            // if we have an API Key, add it to the header
+            if (isPresent(tracesApiKey)) {
+                builder
+                    .addHeader(EnvironmentConfiguration.HONEYCOMB_TEAM_HEADER, tracesApiKey);
+                if (isLegacyKey(tracesApiKey)) {
+                    // if the key is legacy, add dataset to the header
+                    if (isPresent(tracesDataset)) {
+                        builder
+                            .addHeader(EnvironmentConfiguration.HONEYCOMB_DATASET_HEADER, tracesDataset);
+                    } else {
+                        // if legacy key and missing dataset, warn on missing dataset
+                        logger.warning(EnvironmentConfiguration.getErrorMessage("dataset",
+                            EnvironmentConfiguration.HONEYCOMB_DATASET));
+                    }
+                }
+            } else {
+                // warn on missing API Key
+                logger.warning(EnvironmentConfiguration.getErrorMessage("API key",
+                    EnvironmentConfiguration.HONEYCOMB_API_KEY));
+            }
+
+            return builder.build();
         }
     }
 

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -398,12 +398,18 @@ public final class OpenTelemetryConfiguration {
         }
 
         private SpanExporter createHttpSpanExporter(Logger logger) {
-            OtlpHttpSpanExporterBuilder builder = OtlpHttpSpanExporter.builder();
+            String endpoint;
             if (tracesEndpoint != null) {
-                builder.setEndpoint(tracesEndpoint);
+                endpoint = tracesEndpoint;
             } else {
-                builder.setEndpoint(EnvironmentConfiguration.DEFAULT_HONEYCOMB_ENDPOINT);
+                endpoint = EnvironmentConfiguration.DEFAULT_HONEYCOMB_ENDPOINT;
             }
+            // add the "/v1/traces" path if missing
+            if (!endpoint.endsWith(EnvironmentConfiguration.OTLP_HTTP_TRACES_PATH)) {
+                endpoint += EnvironmentConfiguration.OTLP_HTTP_TRACES_PATH;
+            }
+            OtlpHttpSpanExporterBuilder builder = OtlpHttpSpanExporter.builder();
+            builder.setEndpoint(endpoint);
 
             // if we have an API Key, add it to the header
             if (isPresent(tracesApiKey)) {

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -398,12 +398,10 @@ public final class OpenTelemetryConfiguration {
         }
 
         private SpanExporter createHttpSpanExporter(Logger logger) {
-            String endpoint;
-            if (tracesEndpoint != null) {
-                endpoint = tracesEndpoint;
-            } else {
-                endpoint = EnvironmentConfiguration.DEFAULT_HONEYCOMB_ENDPOINT;
-            }
+            // use tracesEndpoint if set, use default if null or empty
+            String endpoint = StringUtils.isNotEmpty(tracesEndpoint) ?
+                tracesEndpoint :
+                EnvironmentConfiguration.DEFAULT_HONEYCOMB_ENDPOINT;
             // add the "/v1/traces" path if missing
             if (!endpoint.endsWith(EnvironmentConfiguration.OTLP_HTTP_TRACES_PATH)) {
                 endpoint += EnvironmentConfiguration.OTLP_HTTP_TRACES_PATH;

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -360,7 +360,7 @@ public final class OpenTelemetryConfiguration {
         }
 
         private SpanExporter getSpanExporter(Logger logger) {
-            return otelExporterOtlpProtocol == EnvironmentConfiguration.OTLP_HTTP_PROTOBUF ?
+            return otelExporterOtlpProtocol.equals(EnvironmentConfiguration.OTLP_HTTP_PROTOBUF) ?
                 createHttpSpanExporter(logger) :
                 createGrpcSpanExporter(logger);
         }

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -55,7 +55,7 @@ public final class OpenTelemetryConfiguration {
         private String tracesDataset;
         private String tracesEndpoint;
         private String serviceName;
-        private String otlpProtocol = EnvironmentConfiguration.getOtelExporterOTLPProtocol();
+        private String otelExporterOtlpProtocol = EnvironmentConfiguration.getOtelExporterOtlpProtocol();
 
         private Builder() {}
 
@@ -263,14 +263,14 @@ public final class OpenTelemetryConfiguration {
 
         /**
          * Sets the OTLP procotol used to export trace spans.
-         * Can be to either 'grpc/protobuf' or 'http/protobuf'.
-         * Default is grpc/protobuf.
+         * Can be to either 'grpc' or 'http/protobuf'.
+         * Default is grpc.
          *
          * @param protocol The protocol to use to export spans with
          * @return Builder
          */
         public Builder setOtlpProtocol(String protocol) {
-            this.otlpProtocol = protocol;
+            this.otelExporterOtlpProtocol = protocol;
             return this;
         }
 
@@ -360,7 +360,7 @@ public final class OpenTelemetryConfiguration {
         }
 
         private SpanExporter getSpanExporter(Logger logger) {
-            return otlpProtocol == EnvironmentConfiguration.OTLP_GRPC_PROTOBUF ?
+            return otelExporterOtlpProtocol == EnvironmentConfiguration.OTLP_GRPC_PROTOBUF ?
                 createHttpSpanExporter(logger) :
                 createGrpcSpanExporter(logger);
         }

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -326,8 +326,8 @@ public final class OpenTelemetryConfiguration {
                 }
             }
 
-            SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder()
-                .setSampler(sampler);
+            SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder();
+            tracerProviderBuilder.setSampler(sampler);
             this.additionalSpanProcessors.forEach(tracerProviderBuilder::addSpanProcessor);
 
             if (this.enableDebug) {
@@ -360,7 +360,7 @@ public final class OpenTelemetryConfiguration {
         }
 
         private SpanExporter getSpanExporter(Logger logger) {
-            return otelExporterOtlpProtocol == EnvironmentConfiguration.OTLP_GRPC_PROTOBUF ?
+            return otelExporterOtlpProtocol == EnvironmentConfiguration.OTLP_HTTP_PROTOBUF ?
                 createHttpSpanExporter(logger) :
                 createGrpcSpanExporter(logger);
         }

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -360,7 +360,7 @@ public final class OpenTelemetryConfiguration {
         }
 
         private SpanExporter getSpanExporter(Logger logger) {
-            return otelExporterOtlpProtocol.equals(EnvironmentConfiguration.OTLP_PROTOCOL_HTTP_PROTOBUF) ?
+            return otelExporterOtlpProtocol.equals(EnvironmentConfiguration.OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF) ?
                 createHttpSpanExporter(logger) :
                 createGrpcSpanExporter(logger);
         }

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -360,7 +360,7 @@ public final class OpenTelemetryConfiguration {
         }
 
         private SpanExporter getSpanExporter(Logger logger) {
-            return otelExporterOtlpProtocol.equals(EnvironmentConfiguration.OTLP_HTTP_PROTOBUF) ?
+            return otelExporterOtlpProtocol.equals(EnvironmentConfiguration.OTLP_PROTOCOL_HTTP_PROTOBUF) ?
                 createHttpSpanExporter(logger) :
                 createGrpcSpanExporter(logger);
         }

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -403,8 +403,8 @@ public final class OpenTelemetryConfiguration {
                 tracesEndpoint :
                 EnvironmentConfiguration.DEFAULT_HONEYCOMB_ENDPOINT;
             // add the "/v1/traces" path if missing
-            if (!endpoint.endsWith(EnvironmentConfiguration.OTLP_HTTP_TRACES_PATH)) {
-                endpoint += EnvironmentConfiguration.OTLP_HTTP_TRACES_PATH;
+            if (!endpoint.endsWith(EnvironmentConfiguration.OTEL_EXPORTER_OTLP_HTTP_TRACES_PATH)) {
+                endpoint += EnvironmentConfiguration.OTEL_EXPORTER_OTLP_HTTP_TRACES_PATH;
             }
             OtlpHttpSpanExporterBuilder builder = OtlpHttpSpanExporter.builder();
             builder.setEndpoint(endpoint);

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '3.0'
 
+x-env-base: &env_base
+  HONEYCOMB_API_KEY: bogus_key
+  HONEYCOMB_DATASET: bogus_dataset
+  HONEYCOMB_METRICS_DATASET: bogus_dataset
+  OTEL_METRIC_EXPORT_INTERVAL: 1000
+
 x-app-base: &app_base
   image: openjdk:17-jdk-alpine
-  environment:
-    HONEYCOMB_API_ENDPOINT: http://collector:4317
-    HONEYCOMB_API_KEY: bogus_key
-    HONEYCOMB_DATASET: bogus_dataset
-    HONEYCOMB_METRICS_DATASET: bogus_dataset
-    OTEL_METRIC_EXPORT_INTERVAL: 1000
   command: "java -javaagent:/agent.jar -jar /app.jar"
   depends_on:
     - collector
@@ -21,6 +21,22 @@ services:
 
   app-agent-manual:
     <<: *app_base
+    environment:
+      <<: *env_base
+      HONEYCOMB_API_ENDPOINT: http://collector:4317
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+    volumes:
+      - "./apps/agent.jar:/agent.jar"
+      - "./apps/spring-agent-manual.jar:/app.jar"
+    ports:
+      - "127.0.0.1:5000:5000"
+
+  app-agent-manual-http:
+    <<: *app_base
+    environment:
+      <<: *env_base
+      HONEYCOMB_API_ENDPOINT: http://collector:4318
+      OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     volumes:
       - "./apps/agent.jar:/agent.jar"
       - "./apps/spring-agent-manual.jar:/app.jar"
@@ -29,14 +45,46 @@ services:
 
   app-agent-only:
     <<: *app_base
+    environment:
+      <<: *env_base
+      HONEYCOMB_API_ENDPOINT: http://collector:4317
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
     volumes:
       - "./apps/agent.jar:/agent.jar"
       - "./apps/spring-agent-only.jar:/app.jar"
     ports:
       - "127.0.0.1:5002:5002"
 
-  app-sdk:
+  app-agent-only-http:
     <<: *app_base
+    environment:
+      <<: *env_base
+      HONEYCOMB_API_ENDPOINT: http://collector:4318
+      OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+    volumes:
+      - "./apps/agent.jar:/agent.jar"
+      - "./apps/spring-agent-only.jar:/app.jar"
+    ports:
+      - "127.0.0.1:5002:5002"
+
+  app-sdk-grpc:
+    <<: *app_base
+    environment:
+      <<: *env_base
+      HONEYCOMB_API_ENDPOINT: http://collector:4317
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+    command: "java -jar /app.jar"
+    volumes:
+      - "./apps/spring-sdk.jar:/app.jar"
+    ports:
+      - "127.0.0.1:5001:5001"
+
+  app-sdk-http:
+    <<: *app_base
+    environment:
+      <<: *env_base
+      HONEYCOMB_API_ENDPOINT: http://collector:4318
+      OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     command: "java -jar /app.jar"
     volumes:
       - "./apps/spring-sdk.jar:/app.jar"

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -31,36 +31,12 @@ services:
     ports:
       - "127.0.0.1:5000:5000"
 
-  app-agent-manual-http:
-    <<: *app_base
-    environment:
-      <<: *env_base
-      HONEYCOMB_API_ENDPOINT: http://collector:4318
-      OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
-    volumes:
-      - "./apps/agent.jar:/agent.jar"
-      - "./apps/spring-agent-manual.jar:/app.jar"
-    ports:
-      - "127.0.0.1:5000:5000"
-
   app-agent-only:
     <<: *app_base
     environment:
       <<: *env_base
       HONEYCOMB_API_ENDPOINT: http://collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
-    volumes:
-      - "./apps/agent.jar:/agent.jar"
-      - "./apps/spring-agent-only.jar:/app.jar"
-    ports:
-      - "127.0.0.1:5002:5002"
-
-  app-agent-only-http:
-    <<: *app_base
-    environment:
-      <<: *env_base
-      HONEYCOMB_API_ENDPOINT: http://collector:4318
-      OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     volumes:
       - "./apps/agent.jar:/agent.jar"
       - "./apps/spring-agent-only.jar:/app.jar"

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.0'
 
 x-env-base: &env_base
+  HONEYCOMB_API_ENDPOINT: http://collector:4317
   HONEYCOMB_API_KEY: bogus_key
   HONEYCOMB_DATASET: bogus_dataset
   HONEYCOMB_METRICS_DATASET: bogus_dataset
@@ -23,8 +24,6 @@ services:
     <<: *app_base
     environment:
       <<: *env_base
-      HONEYCOMB_API_ENDPOINT: http://collector:4317
-      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
     volumes:
       - "./apps/agent.jar:/agent.jar"
       - "./apps/spring-agent-manual.jar:/app.jar"
@@ -35,8 +34,6 @@ services:
     <<: *app_base
     environment:
       <<: *env_base
-      HONEYCOMB_API_ENDPOINT: http://collector:4317
-      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
     volumes:
       - "./apps/agent.jar:/agent.jar"
       - "./apps/spring-agent-only.jar:/app.jar"

--- a/smoke-tests/smoke-sdk-grpc.bats
+++ b/smoke-tests/smoke-sdk-grpc.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+load test_helpers/utilities
+
+CONTAINER_NAME="app-sdk-grpc"
+
+setup_file() {
+	echo "# 🚧" >&3
+	docker-compose up --detach collector ${CONTAINER_NAME}
+	wait_for_ready_app ${CONTAINER_NAME}
+	curl --silent "http://localhost:5001"
+	wait_for_traces
+}
+
+teardown_file() {
+    cp collector/data.json collector/data-results/data-${CONTAINER_NAME}.json
+	docker-compose stop ${CONTAINER_NAME}
+	docker-compose restart collector
+	wait_for_flush
+}
+
+# TESTS
+
+@test "Manual instrumentation produces span with name of span" {
+	result=$(span_names_for 'examples')
+	assert_equal "$result" '"greetings"'
+}
+
+@test "Manual instrumentation adds custom attribute" {
+	result=$(span_attributes_for "examples" | jq "select(.key == \"custom_field\").value.stringValue")
+	assert_equal "$result" '"important value"'
+}

--- a/smoke-tests/smoke-sdk-http.bats
+++ b/smoke-tests/smoke-sdk-http.bats
@@ -2,7 +2,7 @@
 
 load test_helpers/utilities
 
-CONTAINER_NAME="app-sdk-${PROTO}"
+CONTAINER_NAME="app-sdk-http"
 
 setup_file() {
 	echo "# 🚧" >&3

--- a/smoke-tests/smoke-sdk.bats
+++ b/smoke-tests/smoke-sdk.bats
@@ -2,17 +2,19 @@
 
 load test_helpers/utilities
 
+CONTAINER_NAME="app-sdk-${PROTO}"
+
 setup_file() {
 	echo "# 🚧" >&3
-	docker-compose up --detach collector app-sdk
-	wait_for_ready_app 'app-sdk'
+	docker-compose up --detach collector ${CONTAINER_NAME}
+	wait_for_ready_app ${CONTAINER_NAME}
 	curl --silent "http://localhost:5001"
 	wait_for_traces
 }
 
 teardown_file() {
-    cp collector/data.json collector/data-results/data-sdk.json
-	docker-compose stop app-sdk
+    cp collector/data.json collector/data-results/data-${CONTAINER_NAME}.json
+	docker-compose stop ${CONTAINER_NAME}
 	docker-compose restart collector
 	wait_for_flush
 }
@@ -28,5 +30,3 @@ teardown_file() {
 	result=$(span_attributes_for "examples" | jq "select(.key == \"custom_field\").value.stringValue")
 	assert_equal "$result" '"important value"'
 }
-
-


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Add support for the SDK to read the OTEL system property or environment variable used to determine the protocol to send trace spans with the OTLP Span Exporter.

You can set the protocol either in one of the following ways:
- System property: `-Dotel.exporter.otlp.protocol=grpc|http/protobuf`
- Environment variable: `export OTEL_EXPOTER_OTLP_PROTOCOL=grpc|http/protobuf`
- `OpenTelemetryConfiguration.builder().setOtlpProtocol("grpc|http/protobuf")`

- Closes #282 

## Short description of the changes
- Add static properties to EnvironmentConfigurion to OTLP grpc and HTTP protocols
- Add getOtlpProtocol to EnvironmentConfiguration
- Add unit test to verify grpc is default exporter and can swap in HTTP exporter
- Splits sdk-only smoke tests to execute both for grpc and http exporters
  - includes reworking docker compose file and makefile to accommodate dual execution of smoke tests