### PR TITLE
append traces path to endpoint if http with agent

### DIFF
--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -198,7 +198,9 @@ public class EnvironmentConfiguration {
     }
 
     public static void enableOTLPTraces() {
+        final String otelExporterOtlpProtocol = getOtelExporterOtlpProtocol();
         final String endpoint = getHoneycombTracesApiEndpoint();
+        final String httpEndpoint = endpoint + OTEL_EXPORTER_OTLP_HTTP_TRACES_PATH;
         final String apiKey = getHoneycombTracesApiKey();
         final String dataset = getHoneycombTracesDataset();
         final String serviceName = getServiceName();
@@ -220,7 +222,11 @@ public class EnvironmentConfiguration {
             }
         }
 
-        System.setProperty("otel.exporter.otlp.traces.endpoint", endpoint);
+        if (otelExporterOtlpProtocol.equals("http/protobuf")) {
+            System.setProperty("otel.exporter.otlp.traces.endpoint", httpEndpoint);
+        } else {
+            System.setProperty("otel.exporter.otlp.traces.endpoint", endpoint);
+        }
 
         // if we have an API Key, add it to the header
         if (isPresent(apiKey)) {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #294 

## Short description of the changes

- when we added support for traces using `http/protobuf`, we [appended the traces path to the endpoint for SDK usage](https://github.com/honeycombio/honeycomb-opentelemetry-java/blob/main/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java#L407). This PR appends the traces path for Agent usage as well.

Some testing of these changes with both protocols:

![otel-java-http-grpc](https://user-images.githubusercontent.com/29520003/167728654-590c6f51-aec0-4ef3-a575-1a0b6b9fbf2d.png)

