### PR TITLE
Add OTLP version to headers (HTTP & gRPC)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,6 +3,7 @@
 1. Update the `project.version` in the root build.gradle file with the new release version. Snapshot version is one patch bump ahead of the new release (e.g. if we're releasing `1.0.0` then the corresponding snapshot would be `1.0.1`)
 
 2. Update the version in `DistroMetadata.java` with the new release version
+    -  When updating the OTel Agent/SDK version, update the OTLP version header in `DistroMetadata.java`
 
 3. Update the Changelog
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,6 +7,7 @@ def artifactName = "honeycomb-opentelemetry-common"
 description = 'Functionality shared across components of the Honeycomb OpenTelemetry distribution.'
 
 dependencies {
+    compileOnly("org.apache.commons:commons-lang3:3.12.0")
     testImplementation(platform('org.junit:junit-bom:5.8.2'))
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,7 +7,6 @@ def artifactName = "honeycomb-opentelemetry-common"
 description = 'Functionality shared across components of the Honeycomb OpenTelemetry distribution.'
 
 dependencies {
-    compileOnly("org.apache.commons:commons-lang3:3.12.0")
     testImplementation(platform('org.junit:junit-bom:5.8.2'))
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'

--- a/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
@@ -22,6 +22,9 @@ public class DistroMetadata {
     public static final String RUNTIME_VERSION_FIELD = "honeycomb.distro.runtime_version";
     public static final String RUNTIME_VERSION_VALUE = System.getProperty("java.runtime.version");
 
+    public static final String OTLP_PROTO_VERSION_HEADER = "x-otlp-version";
+    public static final String OTLP_PROTO_VERSION_VALUE = "0.16.0";
+
     /**
      * Get Metadata as a map of strings to strings.
      *

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -207,7 +207,7 @@ public class EnvironmentConfiguration {
         final String apiKey = getHoneycombTracesApiKey();
         final String dataset = getHoneycombTracesDataset();
         final String serviceName = getServiceName();
-        final Map<String, String> headers = getHeaders(apiKey, dataset);
+        final Map<String, String> headers = getTracesHeaders(apiKey, dataset);
 
         // helpful to know if service name is missing
         if (!isPresent(serviceName)) {
@@ -245,7 +245,7 @@ public class EnvironmentConfiguration {
         final String endpoint = getHoneycombMetricsApiEndpoint();
         final String apiKey = getHoneycombMetricsApiKey();
         final String dataset = getHoneycombMetricsDataset();
-        final Map<String, String> headers = getHeaders(apiKey, dataset);
+        final Map<String, String> headers = getMetricsHeaders(apiKey, dataset);
 
         if (isPresent(dataset)) {
             System.setProperty("otel.metrics.exporter", "otlp");
@@ -280,7 +280,7 @@ public class EnvironmentConfiguration {
         return properties;
     }
 
-    public static Map<String, String> getHeaders(String apiKey, String dataset) {
+    public static Map<String, String> getTracesHeaders(String apiKey, String dataset) {
         final Map<String, String> headers = new HashMap<String, String>();
         headers.put(DistroMetadata.OTLP_PROTO_VERSION_HEADER, DistroMetadata.OTLP_PROTO_VERSION_VALUE);
         headers.put(HONEYCOMB_TEAM_HEADER, apiKey);
@@ -293,6 +293,14 @@ public class EnvironmentConfiguration {
                 System.out.printf("WARN: %s%n", getErrorMessage("dataset", HONEYCOMB_DATASET));
             }
         }
+        return headers;
+    }
+
+    public static Map<String, String> getMetricsHeaders(String apiKey, String dataset) {
+        final Map<String, String> headers = new HashMap<String, String>();
+        headers.put(DistroMetadata.OTLP_PROTO_VERSION_HEADER, DistroMetadata.OTLP_PROTO_VERSION_VALUE);
+        headers.put(HONEYCOMB_TEAM_HEADER, apiKey);
+        headers.put(HONEYCOMB_DATASET_HEADER, dataset);
         return headers;
     }
 

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -160,7 +160,7 @@ public class EnvironmentConfigurationTest {
         EnvironmentConfiguration.enableOTLPMetrics();
         Assertions.assertEquals("otlp", System.getProperty("otel.metrics.exporter"));
         Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.metrics.endpoint"));
-        Assertions.assertEquals("x-otlp-version=0.16.0,X-Honeycomb-Team=my-key,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
+        Assertions.assertEquals("x-otlp-version=0.16.0,X-Honeycomb-Team=my-key", System.getProperty("otel.exporter.otlp.metrics.headers"));
     }
 
     // make sure OtlpTraces logic doesn't bleed into metrics; dataset still needed

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -139,7 +139,7 @@ public class EnvironmentConfigurationTest {
 
         EnvironmentConfiguration.enableOTLPTraces();
         Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.traces.endpoint"));
-        Assertions.assertEquals("X-Honeycomb-Team=11111111111111111111111111111111,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.traces.headers"));
+        Assertions.assertEquals("x-otlp-version=0.16.0,X-Honeycomb-Team=11111111111111111111111111111111,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.traces.headers"));
     }
 
     @Test
@@ -149,7 +149,7 @@ public class EnvironmentConfigurationTest {
 
         EnvironmentConfiguration.enableOTLPTraces();
         Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.traces.endpoint"));
-        Assertions.assertEquals("X-Honeycomb-Team=specialenvkey", System.getProperty("otel.exporter.otlp.traces.headers"));
+        Assertions.assertEquals("x-otlp-version=0.16.0,X-Honeycomb-Team=specialenvkey", System.getProperty("otel.exporter.otlp.traces.headers"));
     }
 
     @Test
@@ -160,7 +160,7 @@ public class EnvironmentConfigurationTest {
         EnvironmentConfiguration.enableOTLPMetrics();
         Assertions.assertEquals("otlp", System.getProperty("otel.metrics.exporter"));
         Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.metrics.endpoint"));
-        Assertions.assertEquals("X-Honeycomb-Team=my-key,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
+        Assertions.assertEquals("x-otlp-version=0.16.0,X-Honeycomb-Team=my-key,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
     }
 
     // make sure OtlpTraces logic doesn't bleed into metrics; dataset still needed
@@ -172,7 +172,7 @@ public class EnvironmentConfigurationTest {
         EnvironmentConfiguration.enableOTLPMetrics();
         Assertions.assertEquals("otlp", System.getProperty("otel.metrics.exporter"));
         Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.metrics.endpoint"));
-        Assertions.assertEquals("X-Honeycomb-Team=11111111111111111111111111111111,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
+        Assertions.assertEquals("x-otlp-version=0.16.0,X-Honeycomb-Team=11111111111111111111111111111111,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
     }
 
     @Test

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -160,7 +160,7 @@ public class EnvironmentConfigurationTest {
         EnvironmentConfiguration.enableOTLPMetrics();
         Assertions.assertEquals("otlp", System.getProperty("otel.metrics.exporter"));
         Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.metrics.endpoint"));
-        Assertions.assertEquals("x-otlp-version=0.16.0,X-Honeycomb-Team=my-key", System.getProperty("otel.exporter.otlp.metrics.headers"));
+        Assertions.assertEquals("x-otlp-version=0.16.0,X-Honeycomb-Team=my-key,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
     }
 
     // make sure OtlpTraces logic doesn't bleed into metrics; dataset still needed

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import static io.honeycomb.opentelemetry.EnvironmentConfiguration.isPresent;
@@ -375,18 +376,13 @@ public final class OpenTelemetryConfiguration {
 
             // if we have an API Key, add it to the header
             if (isPresent(tracesApiKey)) {
-                builder
-                    .addHeader(EnvironmentConfiguration.HONEYCOMB_TEAM_HEADER, tracesApiKey);
-                if (isLegacyKey(tracesApiKey)) {
-                    // if the key is legacy, add dataset to the header
-                    if (isPresent(tracesDataset)) {
-                        builder
-                            .addHeader(EnvironmentConfiguration.HONEYCOMB_DATASET_HEADER, tracesDataset);
-                    } else {
-                        // if legacy key and missing dataset, warn on missing dataset
-                        logger.warning(EnvironmentConfiguration.getErrorMessage("dataset",
-                            EnvironmentConfiguration.HONEYCOMB_DATASET));
-                    }
+                final Map<String, String> headers = EnvironmentConfiguration.getHeaders(tracesApiKey, tracesDataset);
+                headers.entrySet().forEach(entry -> builder.addHeader(entry.getKey(), entry.getValue()));
+
+                // if legacy key and missing dataset, warn on missing dataset
+                if (isLegacyKey(tracesApiKey) && !isPresent(tracesDataset)) {
+                    logger.warning(EnvironmentConfiguration.getErrorMessage("dataset",
+                        EnvironmentConfiguration.HONEYCOMB_DATASET));
                 }
             } else {
                 // warn on missing API Key
@@ -411,18 +407,13 @@ public final class OpenTelemetryConfiguration {
 
             // if we have an API Key, add it to the header
             if (isPresent(tracesApiKey)) {
-                builder
-                    .addHeader(EnvironmentConfiguration.HONEYCOMB_TEAM_HEADER, tracesApiKey);
-                if (isLegacyKey(tracesApiKey)) {
-                    // if the key is legacy, add dataset to the header
-                    if (isPresent(tracesDataset)) {
-                        builder
-                            .addHeader(EnvironmentConfiguration.HONEYCOMB_DATASET_HEADER, tracesDataset);
-                    } else {
-                        // if legacy key and missing dataset, warn on missing dataset
-                        logger.warning(EnvironmentConfiguration.getErrorMessage("dataset",
-                            EnvironmentConfiguration.HONEYCOMB_DATASET));
-                    }
+                final Map<String, String> headers = EnvironmentConfiguration.getHeaders(tracesApiKey, tracesDataset);
+                headers.entrySet().forEach(entry -> builder.addHeader(entry.getKey(), entry.getValue()));
+
+                // if legacy key and missing dataset, warn on missing dataset
+                if (isLegacyKey(tracesApiKey) && !isPresent(tracesDataset)) {
+                    logger.warning(EnvironmentConfiguration.getErrorMessage("dataset",
+                        EnvironmentConfiguration.HONEYCOMB_DATASET));
                 }
             } else {
                 // warn on missing API Key

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -376,7 +376,7 @@ public final class OpenTelemetryConfiguration {
 
             // if we have an API Key, add it to the header
             if (isPresent(tracesApiKey)) {
-                final Map<String, String> headers = EnvironmentConfiguration.getHeaders(tracesApiKey, tracesDataset);
+                final Map<String, String> headers = EnvironmentConfiguration.getTracesHeaders(tracesApiKey, tracesDataset);
                 headers.entrySet().forEach(entry -> builder.addHeader(entry.getKey(), entry.getValue()));
 
                 // if legacy key and missing dataset, warn on missing dataset
@@ -407,7 +407,7 @@ public final class OpenTelemetryConfiguration {
 
             // if we have an API Key, add it to the header
             if (isPresent(tracesApiKey)) {
-                final Map<String, String> headers = EnvironmentConfiguration.getHeaders(tracesApiKey, tracesDataset);
+                final Map<String, String> headers = EnvironmentConfiguration.getMetricsHeaders(tracesApiKey, tracesDataset);
                 headers.entrySet().forEach(entry -> builder.addHeader(entry.getKey(), entry.getValue()));
 
                 // if legacy key and missing dataset, warn on missing dataset

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -407,7 +407,7 @@ public final class OpenTelemetryConfiguration {
 
             // if we have an API Key, add it to the header
             if (isPresent(tracesApiKey)) {
-                final Map<String, String> headers = EnvironmentConfiguration.getMetricsHeaders(tracesApiKey, tracesDataset);
+                final Map<String, String> headers = EnvironmentConfiguration.getTracesHeaders(tracesApiKey, tracesDataset);
                 headers.entrySet().forEach(entry -> builder.addHeader(entry.getKey(), entry.getValue()));
 
                 // if legacy key and missing dataset, warn on missing dataset


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds the `x-otlp-version` header that indicates what version of OTLP the distro is using. This is useful for understanding what proto versions users are sending to us.

- Implements https://github.com/honeycombio/specs/pull/5

## Short description of the changes
- Add `org.apache.commons` compile dependency to common package
- Extends DistroMetadata to track the `x-otlp-version` header with current value (0.16.0)
- Add EnvironmentConfiguration.getHeaders which creates a `Map<String, String>` that contains the honeycomb and new otlp proto version headers
- Update EnvironmenyConfiguration enableOTLPTraces and enableOTLPMetrics to use new header map
- Update sdk OpenTelemetryConfigurator to use new header map when setting up the builder