### PR TITLE
Fixed false warning  when OTEL_SERVICE_NAME was present.

### DIFF
--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -22,6 +22,7 @@ public class EnvironmentConfiguration {
     public static final String HONEYCOMB_TRACES_DATASET = "HONEYCOMB_TRACES_DATASET";
     public static final String HONEYCOMB_METRICS_DATASET = "HONEYCOMB_METRICS_DATASET";
     public static final String SERVICE_NAME = "SERVICE_NAME";
+    private static final String OTEL_SERVICE_NAME = "OTEL_SERVICE_NAME";
     public static final String SAMPLE_RATE = "SAMPLE_RATE";
     public static final String HONEYCOMB_CONFIGURATION_FILE = "HONEYCOMB_CONFIG_FILE";
 
@@ -134,6 +135,10 @@ public class EnvironmentConfiguration {
         return readVariable(SERVICE_NAME, null);
     }
 
+    private static String getOTelServiceName() {
+        return readVariable(OTEL_SERVICE_NAME, null);
+    }
+
     /**
      * Read the sample rate.
      *
@@ -204,9 +209,10 @@ public class EnvironmentConfiguration {
         final String apiKey = getHoneycombTracesApiKey();
         final String dataset = getHoneycombTracesDataset();
         final String serviceName = getServiceName();
+        final String otelServiceName = getOTelServiceName();
 
         // helpful to know if service name is missing
-        if (!isPresent(serviceName)) {
+        if (!isPresent(serviceName) && !isPresent(otelServiceName)) {
             System.out.printf("WARN: %s%n",
             getErrorMessage("service name", SERVICE_NAME) +
             " If left unset, this will show up in Honeycomb as unknown_service:java");


### PR DESCRIPTION


<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #295 
- Fixed false warning about SERVICE_NAME not being defined when OTEL_SERVICE_NAME was defined. 

## Short description of the changes

- Defined OTEL_SERVICE_NAME private environment variable.
- Created getOTelServiceName private function
- Changed warning logic for missing service name to accept either version.

