### PR TITLE
docs: include onboard docs in releasing, move to top

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Creating a new release
 
-1. Prep public docs PR with the new version (java-distro, otel-java-configuration, otel-java-install, otel-java-run)
+1. Prep public docs PR with the new version (java-distro, otel-java-install, otel-java-run)
 
 1. Prep Onboarding docs PR with the new version (hound/DocsJava)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,18 +1,22 @@
 # Creating a new release
 
+1. Prep public docs PR with the new version (java-distro, otel-java-configuration, otel-java-install, otel-java-run)
+
+1. Prep Onboarding docs PR with the new version (hound/DocsJava)
+
 1. Update the `project.version` in the root build.gradle file with the new release version. Snapshot version is one patch bump ahead of the new release (e.g. if we're releasing `1.0.0` then the corresponding snapshot would be `1.0.1`)
 
-2. Update the version in `DistroMetadata.java` with the new release version
-    -  When updating the OTel Agent/SDK version, update the OTLP version header in `DistroMetadata.java`
+1. Update the version in `DistroMetadata.java` with the new release version
+    - When updating the OTel Agent/SDK version, update the OTLP version header in `DistroMetadata.java`
 
-3. Update the Changelog
+1. Update the Changelog
 
-4. If the new release updates the OpenTelemetry SDK and/or agent versions, update the `Latest release built with` section in the [README](./README.md).
+1. If the new release updates the OpenTelemetry SDK and/or agent versions, update the `Latest release built with` section in the [README](./README.md).
 
-5. Once the above changes are merged into `main`, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off CI, which will publish a draft GitHub release, and publish to Maven.
+1. Once the above changes are merged into `main`, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off CI, which will publish a draft GitHub release, and publish to Maven.
 
-6. Update Release Notes on the new draft GitHub release, and publish that.
+1. Update Release Notes on the new draft GitHub release, and publish that.
 
-7. Update public docs with the new version.
+1. Merge public docs PR and onboard docs PR
 
 Voila!


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- we now also include the distro version in our onboarding quickstart UI - this wasn't listed previously
- sometimes it's easy to miss the docs PR step because it's at the end of the releasing guide

## Short description of the changes

- Move docs PR steps to the top to reduce chance of forgetting as part of the releasing process
- Add specific places for updates in public docs
- Add onboard PR step

