### PR TITLE
maint: add github workflow to auto-create issue for public docs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [published]
 jobs:
-  create_issue:
+  create_issue_public_docs:
     runs-on: ubuntu-latest
     steps:
       - name: Create an issue
@@ -16,5 +16,20 @@ jobs:
             ## Bump otel-java version
 
             Update Java Distro docs to latest version
+
+        assignees: @honeycombio/telemetry-team
+  create_issue_onboard_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create an issue
+        uses: actions-ecosystem/action-create-issue@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          repo: github.com/honeycombio/hound
+          title: ${{ steps.date.outputs.today }}
+          body: |
+            ## Bump otel-java version
+
+            Update Java Distro in Onboarding docs to latest version
 
         assignees: @honeycombio/telemetry-team


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- it's easy to forget to update docs when a new release is published (see #313 which updates releasing notes)

## Short description of the changes

- this workflow should create an issue automatically in the docs repo and assign telemetry team

