### PR TITLE
Decorate existing Sampler with DeterministicTraceSampler instead of replacing it

### DIFF
--- a/common/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
@@ -48,11 +48,15 @@ public class DeterministicTraceSampler implements Sampler {
     public final static String DESCRIPTION = "HoneycombDeterministicSampler";
 
     /**
-     * Creates a DeterministicTraceSampler that, upon determining that a Span should be sampled,
-     * delegates to a decorated Sampler to make the final decision.
+     * Creates a DeterministicTraceSampler which samples a span if the provided decoratedSampler
+     * AND this sampler's deterministic sampleRate both decide that a span should be sampled.
      *
-     * @param decoratedSampler another Sampler which is delegated to when this Sampler thinks that
-     *                         a Span should be sampled.
+     * The decoratedSampler is always called first.
+     * When it doesn't decide to DROP the span, the sampleRate determines the final outcome.
+     *
+     * @param decoratedSampler another Sampler whose decision to sample a span is combined with the
+     *                         sample rate.
+     *
      * @param sampleRate to use - class level javadoc.
      * @throws IllegalArgumentException if sampleRate is negative.
      * @throws IllegalStateException    if SHA-1 is not supported.

--- a/common/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSampler.java
@@ -57,7 +57,7 @@ public class DeterministicTraceSampler implements Sampler {
      * @param decoratedSampler another Sampler whose decision to sample a span is combined with the
      *                         sample rate.
      *
-     * @param sampleRate to use - class level javadoc.
+     * @param sampleRate to use - see class level javadoc.
      * @throws IllegalArgumentException if sampleRate is negative.
      * @throws IllegalStateException    if SHA-1 is not supported.
      */
@@ -80,7 +80,7 @@ public class DeterministicTraceSampler implements Sampler {
      * Creates a DeterministicTraceSampler that makes the final decision about whether to sample
      * a Span based on its sampleRate.
      *
-     * @param sampleRate to use - class level javadoc.
+     * @param sampleRate to use - see class level javadoc.
      * @throws IllegalArgumentException if sampleRate is negative.
      * @throws IllegalStateException    if SHA-1 is not supported.
      */

--- a/common/src/test/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSamplerTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSamplerTest.java
@@ -20,7 +20,7 @@ public class DeterministicTraceSamplerTest {
     @Test
     public void test_neverSample() {
         int sampleRate = 0;
-        Sampler sampler = new DeterministicTraceSampler(Sampler.alwaysOn(), sampleRate);
+        Sampler sampler = new DeterministicTraceSampler(sampleRate);
 
         for (int i = 0; i < 100; i++) {
             String traceID = IdGenerator.random().generateTraceId();
@@ -32,7 +32,7 @@ public class DeterministicTraceSamplerTest {
     @Test
     public void test_alwaysSample() {
         int sampleRate = 1;
-        Sampler sampler = new DeterministicTraceSampler(Sampler.alwaysOn(), sampleRate);
+        Sampler sampler = new DeterministicTraceSampler(sampleRate);
 
         for (int i = 0; i < 100; i++) {
             String traceID = IdGenerator.random().generateTraceId();
@@ -45,7 +45,7 @@ public class DeterministicTraceSamplerTest {
     public void test_samplingResult_has_sampleRate_attribute() {
 
         for (int i = 0; i < 10; i++) {
-            Sampler sampler = new DeterministicTraceSampler(Sampler.alwaysOn(), i);
+            Sampler sampler = new DeterministicTraceSampler(i);
             String traceID = IdGenerator.random().generateTraceId();
             SamplingResult result = sampler.shouldSample(Context.current(), traceID, "span", SpanKind.CLIENT, Attributes.empty(), Collections.emptyList());
 
@@ -60,7 +60,7 @@ public class DeterministicTraceSamplerTest {
     public void test_deterministicSampler_varies_sampling_decision_based_on_trace_id() {
         int count = 0;
         for (int i = 0; i < 100; i++) {
-            Sampler sampler = new DeterministicTraceSampler(Sampler.alwaysOn(), 2);
+            Sampler sampler = new DeterministicTraceSampler(2);
             String traceID = IdGenerator.random().generateTraceId();
             SamplingResult result = sampler.shouldSample(Context.current(), traceID, "span", SpanKind.CLIENT, Attributes.empty(), Collections.emptyList());
             if (result.getDecision() == SamplingDecision.RECORD_AND_SAMPLE) {

--- a/common/src/test/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSamplerTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/sdk/trace/samplers/DeterministicTraceSamplerTest.java
@@ -1,24 +1,26 @@
 package io.honeycomb.opentelemetry.sdk.trace.samplers;
 
-import java.util.Collections;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
-import io.opentelemetry.sdk.trace.IdGenerator;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
-import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
-import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 public class DeterministicTraceSamplerTest {
 
     @Test
     public void test_neverSample() {
         int sampleRate = 0;
-        Sampler sampler = new DeterministicTraceSampler(sampleRate);
+        Sampler sampler = new DeterministicTraceSampler(Sampler.alwaysOn(), sampleRate);
 
         for (int i = 0; i < 100; i++) {
             String traceID = IdGenerator.random().generateTraceId();
@@ -30,7 +32,7 @@ public class DeterministicTraceSamplerTest {
     @Test
     public void test_alwaysSample() {
         int sampleRate = 1;
-        Sampler sampler = new DeterministicTraceSampler(sampleRate);
+        Sampler sampler = new DeterministicTraceSampler(Sampler.alwaysOn(), sampleRate);
 
         for (int i = 0; i < 100; i++) {
             String traceID = IdGenerator.random().generateTraceId();
@@ -43,7 +45,7 @@ public class DeterministicTraceSamplerTest {
     public void test_samplingResult_has_sampleRate_attribute() {
 
         for (int i = 0; i < 10; i++) {
-            Sampler sampler = new DeterministicTraceSampler(i);
+            Sampler sampler = new DeterministicTraceSampler(Sampler.alwaysOn(), i);
             String traceID = IdGenerator.random().generateTraceId();
             SamplingResult result = sampler.shouldSample(Context.current(), traceID, "span", SpanKind.CLIENT, Attributes.empty(), Collections.emptyList());
 
@@ -58,7 +60,7 @@ public class DeterministicTraceSamplerTest {
     public void test_deterministicSampler_varies_sampling_decision_based_on_trace_id() {
         int count = 0;
         for (int i = 0; i < 100; i++) {
-            Sampler sampler = new DeterministicTraceSampler(2);
+            Sampler sampler = new DeterministicTraceSampler(Sampler.alwaysOn(), 2);
             String traceID = IdGenerator.random().generateTraceId();
             SamplingResult result = sampler.shouldSample(Context.current(), traceID, "span", SpanKind.CLIENT, Attributes.empty(), Collections.emptyList());
             if (result.getDecision() == SamplingDecision.RECORD_AND_SAMPLE) {
@@ -67,5 +69,43 @@ public class DeterministicTraceSamplerTest {
         }
 
         Assertions.assertTrue(count > 25 && count < 75);
+    }
+
+    @Test
+    public void test_delegatesToDecoratedSampler() {
+        int sampleRate = 1;
+        Sampler sampler = new DeterministicTraceSampler(Sampler.alwaysOff(), sampleRate);
+
+        for (int i = 0; i < 100; i++) {
+            String traceID = IdGenerator.random().generateTraceId();
+            SamplingResult result = sampler.shouldSample(Context.current(), traceID, "span", SpanKind.CLIENT, Attributes.empty(), Collections.emptyList());
+            Assertions.assertEquals(SamplingDecision.DROP, result.getDecision());
+        }
+    }
+
+    @Test
+    public void test_includesAttributesOfDecoratedSampler() {
+        AttributeKey<String> attributeKey = AttributeKey.stringKey("test.attribute.name");
+        String attributeValue = "test.attribute.value";
+        Attributes attributes = Attributes.of(attributeKey, attributeValue);
+        SamplingResult decoratorResult = SamplingResult.create(SamplingDecision.RECORD_AND_SAMPLE, attributes);
+        Sampler decoratedSampler = new Sampler() {
+            @Override
+            public SamplingResult shouldSample(Context parentContext, String traceId, String name, SpanKind spanKind, Attributes attributes, List<LinkData> parentLinks) {
+                return decoratorResult;
+            }
+
+            @Override
+            public String getDescription() {return "test_includesAttributesOfDecoratedSampler()";}
+        };
+
+        int sampleRate = 1;
+        Sampler sampler = new DeterministicTraceSampler(decoratedSampler, sampleRate);
+
+        for (int i = 0; i < 100; i++) {
+            String traceID = IdGenerator.random().generateTraceId();
+            SamplingResult result = sampler.shouldSample(Context.current(), traceID, "span", SpanKind.CLIENT, Attributes.empty(), Collections.emptyList());
+            Assertions.assertEquals(result.getAttributes().get(attributeKey), attributeValue);
+        }
     }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #315: Agent Auto Configuration can overwrite an extension's customer Sampler

## Short description of the changes

Changes the way the Honeycomb agent configures the tracer by decorating the existing Sampler rather than replacing it. Also changes the implementation of DeterministicTraceSampler to function as a decorating/filtering Sampler rather than 100% authoritative.

