### PR TITLE
produce a JSON of release info on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .mtj.tmp/
 
 # Package Files #
+build-artifacts/
 *.jar
 *.war
 *.nar

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,19 @@ tasks.register('project_version') {
     }
 }
 
+def releaseInfoTask = tasks.register('releaseInfo') {
+    doLast {
+        def releaseInfo = new TreeMap<String,Object>()
+        releaseInfo["repo_name"] = "honeycombio/honeycomb-opentelemetry-java"
+        releaseInfo["version"] = project.version
+
+        def releaseJsonFile = file("$rootDir/build-artifacts/release.json")
+        def releaseJson = groovy.json.JsonOutput.toJson(releaseInfo)
+        releaseJsonFile.write groovy.json.JsonOutput.prettyPrint(releaseJson)
+    }
+}
+
+
 subprojects {
     version = rootProject.version
 
@@ -55,6 +68,7 @@ subprojects {
     }
     tasks.withType(Jar) {
         destinationDirectory = file("$rootDir/build-artifacts")
+        finalizedBy releaseInfoTask
     }
 
     plugins.withId("maven-publish") {


### PR DESCRIPTION
## Which problem is this PR solving?

- Something to inform automation about release data like versions and possibly shasums and the like in the future.
- For the short term, intended to help updating the documentation site with latest version info.

## Short description of the changes

- Include it in release artifacts!

## Example output:

```
» ./gradlew build
BUILD SUCCESSFUL in 4s
57 actionable tasks: 5 executed, 52 up-to-date

» cat build-artifacts/release.json 
{
  "repo_name": "honeycombio/honeycomb-opentelemetry-java",
  "version": "1.2.1-SNAPSHOT"
}
```