### PR TITLE
maint: add un-versioned copy of agent to Github assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: "Add Un-versioned Copy of Agent - TESTING FOR PR"
           command: |
             echo "about to add copy of un-versioned agent"
-            cp build-artifacts/honeycomb-opentelemetry-javaagent*[!A-Z,a-z].jar build-artifacts/honeycomb-opentelemetry-javaagent.jar
+            cp build-artifacts/honeycomb-opentelemetry-javaagent*[!a-z].jar build-artifacts/honeycomb-opentelemetry-javaagent.jar
       - run:
           name: Show the JARs
           command: ls -l build-artifacts
@@ -67,8 +67,8 @@ jobs:
           name: "Add Un-versioned Copy of Agent to GitHub"
           command: |
             echo "about to add copy of un-versioned agent"
-            ls -ld ./publish-artifacts/honeycomb-opentelemetry-javaagent*[!A-Z,a-z].jar
-            cp ./publish-artifacts/honeycomb-opentelemetry-javaagent*[!A-Z,a-z].jar ./publish-artifacts/honeycomb-opentelemetry-javaagent.jar
+            ls -ld ./publish-artifacts/honeycomb-opentelemetry-javaagent*[!a-z].jar
+            cp ./publish-artifacts/honeycomb-opentelemetry-javaagent*[!a-z].jar ./publish-artifacts/honeycomb-opentelemetry-javaagent.jar
       - run:
           name: "Publish Release on GitHub"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,12 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
+          name: "Add Un-versioned Copy of Agent to GitHub"
+          command: |
+            echo "about to add copy of un-versioned agent"
+            ls -ld ./publish-artifacts/honeycomb-opentelemetry-javaagent*[!A-Z,a-z].jar
+            cp ./publish-artifacts/honeycomb-opentelemetry-javaagent*[!A-Z,a-z].jar ./publish-artifacts/honeycomb-opentelemetry-javaagent.jar
+      - run:
           name: "Publish Release on GitHub"
           command: |
             echo "about to publish to tag ${CIRCLE_TAG}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,15 @@ jobs:
       - run:
           name: Show the JARs
           command: ls -l build-artifacts
+      - run:
+          name: "Add Un-versioned Copy of Agent - TESTING FOR PR"
+          command: |
+            echo "about to add copy of un-versioned agent"
+            ls -ld ./build-artifacts/honeycomb-opentelemetry-javaagent*[!A-Z,a-z].jar
+            cp ./build-artifacts/honeycomb-opentelemetry-javaagent*[!A-Z,a-z].jar ./build-artifacts/honeycomb-opentelemetry-javaagent.jar
+      - run:
+          name: Show the JARs
+          command: ls -l build-artifacts
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: "Add Un-versioned Copy of Agent - TESTING FOR PR"
           command: |
             echo "about to add copy of un-versioned agent"
-            cp ./build-artifacts/honeycomb-opentelemetry-javaagent*[!A-Z,a-z].jar ./build-artifacts/honeycomb-opentelemetry-javaagent.jar
+            cp build-artifacts/honeycomb-opentelemetry-javaagent*[!A-Z,a-z].jar build-artifacts/honeycomb-opentelemetry-javaagent.jar
       - run:
           name: Show the JARs
           command: ls -l build-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,6 @@ jobs:
       - run:
           name: Show the JARs
           command: ls -l build-artifacts
-      - run:
-          name: "Add Un-versioned Copy of Agent - TESTING FOR PR"
-          command: |
-            echo "about to add copy of un-versioned agent"
-            cp build-artifacts/honeycomb-opentelemetry-javaagent*[!a-z].jar build-artifacts/honeycomb-opentelemetry-javaagent.jar
-      - run:
-          name: Show the JARs
-          command: ls -l build-artifacts
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
           name: "Add Un-versioned Copy of Agent - TESTING FOR PR"
           command: |
             echo "about to add copy of un-versioned agent"
-            ls -ld ./build-artifacts/honeycomb-opentelemetry-javaagent*[!A-Z,a-z].jar
             cp ./build-artifacts/honeycomb-opentelemetry-javaagent*[!A-Z,a-z].jar ./build-artifacts/honeycomb-opentelemetry-javaagent.jar
       - run:
           name: Show the JARs


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #317 

## Short description of the changes

- copy the versioned agent and rename without the version
- the glob pattern specifies any file in the directory that starts with honeycomb-opentelemetry-javaagent and does not include any letters afterward before ending in `.jar`. The goal is to get only the main agent jar (e.g. `honeycomb-opentelemetry-javaagent-1.2.3.jar`) and exclude `honeycomb-opentelemetry-javaagent-1.2.3-sources.jar`, `-javadoc.jar`,  etc.

selected results from local circle testing:

```
-rw-r--r-- 1 circleci circleci 14330009 Jul  5 22:22 honeycomb-opentelemetry-javaagent-1.2.42.jar
-rw-r--r-- 1 circleci circleci    18699 Jul  5 22:22 honeycomb-opentelemetry-javaagent-1.2.42-javadoc.jar
-rw-r--r-- 1 circleci circleci     1090 Jul  5 22:22 honeycomb-opentelemetry-javaagent-1.2.42-sources.jar
```

after

```
-rw-r--r-- 1 circleci circleci 14330009 Jul  5 22:22 honeycomb-opentelemetry-javaagent-1.2.42.jar
-rw-r--r-- 1 circleci circleci    18699 Jul  5 22:22 honeycomb-opentelemetry-javaagent-1.2.42-javadoc.jar
-rw-r--r-- 1 circleci circleci     1090 Jul  5 22:22 honeycomb-opentelemetry-javaagent-1.2.42-sources.jar
-rw-r--r-- 1 circleci circleci 14330009 Jul  5 22:22 honeycomb-opentelemetry-javaagent.jar
```

testing in circle ci - [successful result](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-java/1328/workflows/88e171d7-5931-47d4-a75e-3ab4749d2fe5/jobs/5665/parallel-runs/0/steps/0-109):

```
-rw-r--r-- 1 circleci circleci 14330015 Jul 14 20:35 honeycomb-opentelemetry-javaagent-1.2.1-SNAPSHOT.jar
-rw-r--r-- 1 circleci circleci    18791 Jul 14 20:35 honeycomb-opentelemetry-javaagent-1.2.1-SNAPSHOT-javadoc.jar
-rw-r--r-- 1 circleci circleci     1090 Jul 14 20:35 honeycomb-opentelemetry-javaagent-1.2.1-SNAPSHOT-sources.jar
-rw-r--r-- 1 circleci circleci 14330015 Jul 14 20:36 honeycomb-opentelemetry-javaagent.jar
```