### PR TITLE
maint: include generated release.yml in published artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,10 @@ jobs:
                 name: "Publish Artifacts to Maven"
                 command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
             - run:
+                name: "Collect Artifacts Published"
                 command: |
                   shopt -s globstar
+                  cp build-artifacts/release.yml ./publish-artifacts
                   cp build-artifacts/*.jar ./publish-artifacts
             - persist_to_workspace:
                 root: ./


### PR DESCRIPTION
Follow up to honeycombio/honeycomb-opentelemetry-java#319

release.yaml doesn't get published to Maven, but is persisted in `./publish-artifacts` so that it is included in the artifacts stored for this job and in the artifacts included in the `publish_github` job.