### PR TITLE
maint: add Java 18 to CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,8 @@ matrix_executors: &matrix_executors
           tag: "11.0"
         - name: gradle/default
           tag: "17.0"
+        - name: gradle/default
+          tag: "18.0"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  gradle: circleci/gradle@2.2.0
+  gradle: circleci/gradle@3.0.0
   bats: circleci/bats@1.0.0
 
 jobs:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Java 18 was released in March 😄 

## Short description of the changes

- add to test matrix
- bump to latest gradle orb while we're at it

