### PR TITLE
maint: notify slack on failed builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,15 @@ version: 2.1
 orbs:
   gradle: circleci/gradle@3.0.0
   bats: circleci/bats@1.0.0
+  slack: circleci/slack@4.10.1
+
+slack_notify_failed_main: &slack_notify_failed_main
+  post-steps:
+    - slack/notify:
+        event: fail
+        branch_pattern: main
+        channel: team-telemetry-oncall-stream
+        template: basic_fail_1
 
 jobs:
   build:
@@ -135,32 +144,40 @@ workflows:
     jobs:
       - gradle/test:
           <<: *matrix_executors
+          <<: *slack_notify_failed_main
       - build:
           requires:
             - gradle/test
+          <<: *slack_notify_failed_main
       - smoke_test:
           requires:
             - build
+          <<: *slack_notify_failed_main
   build:
     jobs:
       - gradle/test:
           <<: *matrix_executors
           <<: *filters_always
+          <<: *slack_notify_failed_main
       - build:
           <<: *filters_always
           requires:
             - gradle/test
+          <<: *slack_notify_failed_main
       - smoke_test:
           <<: *filters_always
           requires:
             - build
+          <<: *slack_notify_failed_main
       - publish_maven:
           <<: *filters_main_only
           context: java_beeline
           requires:
             - smoke_test
+          <<: *slack_notify_failed_main
       - publish_github:
           <<: *filters_tags_only
           context: Honeycomb Secrets for Public Repos
           requires:
             - publish_maven
+          <<: *slack_notify_failed_main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,12 +173,14 @@ workflows:
           context: Slack
       - build:
           <<: *filters_not_forked
+          name: build
           requires:
             - gradle/test
           <<: *slack_notify_failed_main
           context: Slack
       - smoke_test:
           <<: *filters_not_forked
+          name: smoke_test
           requires:
             - build
           <<: *slack_notify_failed_main
@@ -199,7 +201,7 @@ workflows:
           requires:
             - publish_maven
           <<: *slack_notify_failed_main
-# forked PR & dependabot jobs
+# forked & dependabot
       - gradle/test:
           matrix:
             alias: test_forked

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,19 +168,18 @@ workflows:
       - gradle/test:
           <<: *filters_not_forked
           matrix:
+            alias: test
             <<: *matrix_executors
           <<: *slack_notify_failed_main
           context: Slack
       - build:
           <<: *filters_not_forked
-          name: build
           requires:
-            - gradle/test
+            - test
           <<: *slack_notify_failed_main
           context: Slack
       - smoke_test:
           <<: *filters_not_forked
-          name: smoke_test
           requires:
             - build
           <<: *slack_notify_failed_main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ slack_notify_failed_main: &slack_notify_failed_main
   post-steps:
     - slack/notify:
         event: fail
-#        branch_pattern: main
+        branch_pattern: main
         channel: team-telemetry-oncall-stream
         template: basic_fail_1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ slack_notify_failed_main: &slack_notify_failed_main
   post-steps:
     - slack/notify:
         event: fail
-        branch_pattern: main
+#        branch_pattern: main
         channel: team-telemetry-oncall-stream
         template: basic_fail_1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,15 +144,12 @@ workflows:
     jobs:
       - gradle/test:
           <<: *matrix_executors
-          <<: *slack_notify_failed_main
       - build:
           requires:
             - gradle/test
-          <<: *slack_notify_failed_main
       - smoke_test:
           requires:
             - build
-          <<: *slack_notify_failed_main
   build:
     jobs:
       - gradle/test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,10 +99,14 @@ jobs:
             - store_artifacts:
                 path: ./publish-artifacts
 
-filters_always: &filters_always
+filters_not_forked: &filters_not_forked
   filters:
     tags:
       only: /.*/
+    branches:
+      ignore:
+        - /pull\/.*/
+        - /dependabot\/.*/
 
 filters_main_only: &filters_main_only
   filters:
@@ -118,18 +122,26 @@ filters_tags_only: &filters_tags_only
     branches:
       ignore: /.*/
 
+filters_forked_only: &filters_forked_only
+  filters:
+    tags:
+      only: /.*/
+    branches:
+      only:
+        - /pull\/.*/
+        - /dependabot\/.*/
+
 matrix_executors: &matrix_executors
-  matrix:
-    parameters:
-      executor:
-        - name: gradle/default
-          tag: "8.0"
-        - name: gradle/default
-          tag: "11.0"
-        - name: gradle/default
-          tag: "17.0"
-        - name: gradle/default
-          tag: "18.0"
+  parameters:
+    executor:
+      - name: gradle/default
+        tag: "8.0"
+      - name: gradle/default
+        tag: "11.0"
+      - name: gradle/default
+        tag: "17.0"
+      - name: gradle/default
+        tag: "18.0"
 
 workflows:
   version: 2
@@ -143,7 +155,8 @@ workflows:
                 - main
     jobs:
       - gradle/test:
-          <<: *matrix_executors
+          matrix:
+            <<: *matrix_executors
       - build:
           requires:
             - gradle/test
@@ -153,28 +166,52 @@ workflows:
   build:
     jobs:
       - gradle/test:
-          <<: *matrix_executors
-          <<: *filters_always
+          <<: *filters_not_forked
+          matrix:
+            <<: *matrix_executors
           <<: *slack_notify_failed_main
+          context: Slack
       - build:
-          <<: *filters_always
+          <<: *filters_not_forked
           requires:
             - gradle/test
           <<: *slack_notify_failed_main
+          context: Slack
       - smoke_test:
-          <<: *filters_always
+          <<: *filters_not_forked
           requires:
             - build
           <<: *slack_notify_failed_main
+          context: Slack
       - publish_maven:
           <<: *filters_main_only
-          context: java_beeline
+          context:
+           - java_beeline
+           - Slack
           requires:
             - smoke_test
           <<: *slack_notify_failed_main
       - publish_github:
           <<: *filters_tags_only
-          context: Honeycomb Secrets for Public Repos
+          context:
+            - Honeycomb Secrets for Public Repos
+            - Slack
           requires:
             - publish_maven
           <<: *slack_notify_failed_main
+# forked PR & dependabot jobs
+      - gradle/test:
+          matrix:
+            alias: test_forked
+            <<: *matrix_executors
+          <<: *filters_forked_only
+      - build:
+          name: build_forked
+          <<: *filters_forked_only
+          requires:
+            - test_forked
+      - smoke_test:
+          name: smoke_test_forked
+          <<: *filters_forked_only
+          requires:
+            - build_forked

--- a/common/src/test/java/io/honeycomb/opentelemetry/sdk/trace/spanprocessors/BaggageSpanProcessorTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/sdk/trace/spanprocessors/BaggageSpanProcessorTest.java
@@ -28,7 +28,7 @@ public class BaggageSpanProcessorTest {
                 .makeCurrent();
 
             processor.onStart(Context.current(), span);
-            Mockito.verify(span).setAttribute("key", "value");
+            Mockito.verify(span).setAttribute("key", "foo");
         }
     }
 }

--- a/common/src/test/java/io/honeycomb/opentelemetry/sdk/trace/spanprocessors/BaggageSpanProcessorTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/sdk/trace/spanprocessors/BaggageSpanProcessorTest.java
@@ -28,7 +28,7 @@ public class BaggageSpanProcessorTest {
                 .makeCurrent();
 
             processor.onStart(Context.current(), span);
-            Mockito.verify(span).setAttribute("key", "foo");
+            Mockito.verify(span).setAttribute("key", "value");
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- we miss failing CI builds on main
- send a slack notification to our oncall channel on failed builds on main branch

## Short description of the changes

- had to do some weird stuff to make it work in such a way that we get notified while forked & dependabot PRs continue to build
- `context: Slack` is the thing that has the token to send a Slack notifications
- forked PRs (and dependabots) don't get access to secret contexts because security 🔒 which means that those builds would just fail to start as "Unauthorized"
- I wish we could just have external builds ignore the context but that's not how Circle works 😢 

[example of a forked build](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-java/1411/workflows/758a2193-b914-48fd-9f75-0efa43cbf794) - no slack notification step and no secrets requried

Is this extra config mess worth the Slack notifications?

