### PR TITLE
Update Otel SDK and JavaAgent to v1.19.0/v1.19.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It makes getting started with OpenTelemetry and Honeycomb easier!
 
 Latest release built with:
 
-- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.19.0) version 1.19.0
-- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.19.1) version 1.19.1
+- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.14.0) version 1.14.0
+- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.14.0) version 1.14.0
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It makes getting started with OpenTelemetry and Honeycomb easier!
 
 Latest release built with:
 
-- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.14.0) version 1.14.0
-- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.14.0) version 1.14.0
+- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.19.0) version 1.19.0
+- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.19.1) version 1.19.1
 
 ## Getting Started
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry         : "1.18.0",
-                opentelemetryJavaagent: "1.18.0",
+                opentelemetry         : "1.19.0",
+                opentelemetryJavaagent: "1.19.1",
                 bytebuddy             : "1.10.18",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry         : "1.19.0",
-                opentelemetryJavaagent: "1.19.1",
+                opentelemetry         : "1.18.0",
+                opentelemetryJavaagent: "1.18.0",
                 bytebuddy             : "1.10.18",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry         : "1.14.0",
-                opentelemetryJavaagent: "1.14.0",
+                opentelemetry         : "1.19.0",
+                opentelemetryJavaagent: "1.19.1",
                 bytebuddy             : "1.10.18",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"

--- a/examples/spring-agent-manual/src/main/java/io/honeycomb/examples/springbootagentmanual/HelloController.java
+++ b/examples/spring-agent-manual/src/main/java/io/honeycomb/examples/springbootagentmanual/HelloController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 
 @RestController
 public class HelloController {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -8,11 +8,10 @@ description = 'Honeycomb SDK for manually configuring OpenTelemetry instrumentat
 
 dependencies {
     api "io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}"
-    api "io.opentelemetry:opentelemetry-extension-annotations:${versions.opentelemetry}"
+    api "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:${versions.opentelemetryJavaagentAlpha}"
 
     implementation "io.opentelemetry:opentelemetry-exporter-logging:${versions.opentelemetry}"
     implementation "io.opentelemetry:opentelemetry-exporter-otlp:${versions.opentelemetry}"
-    implementation "io.opentelemetry:opentelemetry-exporter-otlp-http-trace:${versions.opentelemetry}"
     implementation "io.opentelemetry:opentelemetry-sdk-extension-resources:${versions.opentelemetry}"
 
     implementation 'io.grpc:grpc-netty-shaded:1.47.0'

--- a/smoke-tests/smoke-agent-manual.bats
+++ b/smoke-tests/smoke-agent-manual.bats
@@ -30,7 +30,7 @@ teardown_file() {
 }
 
 @test "Manual instrumentation produces span from @WithSpan annotation" {
-	result=$(span_names_for "io.opentelemetry.opentelemetry-annotations-1.0")
+	result=$(span_names_for "io.opentelemetry.opentelemetry-instrumentation-annotations-1.16")
 	assert_equal "$result" '"importantSpan"'
 }
 
@@ -40,6 +40,6 @@ teardown_file() {
 }
 
 @test "BaggageSpanProcessor: key-values added to baggage appear on child spans" {
-	result=$(span_attributes_for "io.opentelemetry.opentelemetry-annotations-1.0" | jq "select(.key == \"for_the_children\").value.stringValue")
+	result=$(span_attributes_for "io.opentelemetry.opentelemetry-instrumentation-annotations-1.16" | jq "select(.key == \"for_the_children\").value.stringValue")
 	assert_equal "$result" '"another important value"'
 }


### PR DESCRIPTION
# Which problem is this PR solving?
Updates the OpenTelemetry SDK and JavaAgent dependencies to latest. Includes replacing the relocated `opentelemetry-extension-annotations` package the instrumentation repo and removing the OTLP HTTP exporter package as it's no longer required.

## Short description of the changes
- Update OTel SDK to v1.19.0
- Update OTel JavaAgent to v1.19.1
- Replace extension-annotation package with new instrumentation-annotations package
- Updates example to use new import statement for `WithSpan`
- Remove OTLP http exporter package as it's now part of the `opentelemetry-exporter-otlp` package
- Update smoke tests to use new annotations package name