### PR TITLE
maint: don't run extra jobs when releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,8 +123,6 @@ filters_tags_only: &filters_tags_only
 
 filters_forked_only: &filters_forked_only
   filters:
-    tags:
-      only: /.*/
     branches:
       only:
         - /pull\/.*/


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- [release pipeline](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-java/1508/workflows/040caa3a-e8f8-477d-a93a-f6f26dd5a5e5) runs "forked-only" jobs, which are redundant

## Short description of the changes

- forked-only filter need not target tags, only specific branches

