### PR TITLE
maint: additional metadata to diff sdk from agent

### DIFF
--- a/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
@@ -19,6 +19,9 @@ public class DistroMetadata {
      * Java agent.
      */
     public static final String VERSION_VALUE = "1.4.0";
+    public static final String VARIANT_FIELD = "honeycomb.distro.variant";
+    public static final String VARIANT_AGENT = "agent";
+    public static final String VARIANT_SDK = "sdk";
     public static final String RUNTIME_VERSION_FIELD = "honeycomb.distro.runtime_version";
     public static final String RUNTIME_VERSION_VALUE = System.getProperty("java.runtime.version");
 
@@ -29,11 +32,28 @@ public class DistroMetadata {
      * Get Metadata as a map of strings to strings.
      *
      * @return map of metadata to include as resource attributes.
+     * @deprecated use getAgentMetadata() or getSDKMetadata() instead
      */
     public static Map<String, String> getMetadata() {
         Map<String, String> metadata = new HashMap<String, String>();
         metadata.put(VERSION_FIELD, VERSION_VALUE);
         metadata.put(RUNTIME_VERSION_FIELD, RUNTIME_VERSION_VALUE);
+        return metadata;
+    }
+
+    public static Map<String, String> getAgentMetadata() {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(VERSION_FIELD, VERSION_VALUE);
+        metadata.put(RUNTIME_VERSION_FIELD, RUNTIME_VERSION_VALUE);
+        metadata.put(VARIANT_FIELD, VARIANT_AGENT);
+        return metadata;
+    }
+
+    public static Map<String, String> getSDKMetadata() {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(VERSION_FIELD, VERSION_VALUE);
+        metadata.put(RUNTIME_VERSION_FIELD, RUNTIME_VERSION_VALUE);
+        metadata.put(VARIANT_FIELD, VARIANT_SDK);
         return metadata;
     }
 }

--- a/common/src/test/java/io/honeycomb/opentelemetry/DistroMetadataTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/DistroMetadataTest.java
@@ -1,18 +1,31 @@
 package io.honeycomb.opentelemetry;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 public class DistroMetadataTest {
 
     @Test
-    public void test_distroMetadata_returns_expected_values() {
-        Map<String, String> metadata = DistroMetadata.getMetadata();
-        Assertions.assertNotNull(metadata.containsKey(DistroMetadata.VERSION_FIELD));
+    public void test_agentMetadata_returns_expected_values() {
+        Map<String, String> metadata = DistroMetadata.getAgentMetadata();
+        Assertions.assertTrue(metadata.containsKey(DistroMetadata.VERSION_FIELD));
         Assertions.assertEquals(metadata.get(DistroMetadata.VERSION_FIELD), DistroMetadata.VERSION_VALUE);
-        Assertions.assertNotNull(metadata.containsKey(DistroMetadata.RUNTIME_VERSION_FIELD));
+        Assertions.assertTrue(metadata.containsKey(DistroMetadata.RUNTIME_VERSION_FIELD));
         Assertions.assertEquals(metadata.get(DistroMetadata.RUNTIME_VERSION_FIELD), DistroMetadata.RUNTIME_VERSION_VALUE);
+        Assertions.assertTrue(metadata.containsKey(DistroMetadata.VARIANT_FIELD));
+        Assertions.assertEquals(metadata.get(DistroMetadata.VARIANT_FIELD), DistroMetadata.VARIANT_AGENT);
+    }
+
+    @Test
+    public void test_sdkMetadata_returns_expected_values() {
+        Map<String, String> metadata = DistroMetadata.getSDKMetadata();
+        Assertions.assertTrue(metadata.containsKey(DistroMetadata.VERSION_FIELD));
+        Assertions.assertEquals(metadata.get(DistroMetadata.VERSION_FIELD), DistroMetadata.VERSION_VALUE);
+        Assertions.assertTrue(metadata.containsKey(DistroMetadata.RUNTIME_VERSION_FIELD));
+        Assertions.assertEquals(metadata.get(DistroMetadata.RUNTIME_VERSION_FIELD), DistroMetadata.RUNTIME_VERSION_VALUE);
+        Assertions.assertTrue(metadata.containsKey(DistroMetadata.VARIANT_FIELD));
+        Assertions.assertEquals(metadata.get(DistroMetadata.VARIANT_FIELD), DistroMetadata.VARIANT_SDK);
     }
 }

--- a/custom/src/main/java/io/honeycomb/opentelemetry/DistroMetadataResourceProvider.java
+++ b/custom/src/main/java/io/honeycomb/opentelemetry/DistroMetadataResourceProvider.java
@@ -10,7 +10,7 @@ public class DistroMetadataResourceProvider implements ResourceProvider {
     @Override
     public Resource createResource(ConfigProperties config) {
         AttributesBuilder attributesBuilder = Attributes.builder();
-        DistroMetadata.getMetadata().forEach(attributesBuilder::put);
+        DistroMetadata.getAgentMetadata().forEach(attributesBuilder::put);
         return Resource.create(attributesBuilder.build());
     }
 }

--- a/custom/src/test/java/io/honeycomb/opentelemetry/DistroMetadataResourceProviderTest.java
+++ b/custom/src/test/java/io/honeycomb/opentelemetry/DistroMetadataResourceProviderTest.java
@@ -17,7 +17,8 @@ public class DistroMetadataResourceProviderTest {
         Assertions.assertEquals(
             Attributes.of(
                 AttributeKey.stringKey(DistroMetadata.VERSION_FIELD), DistroMetadata.VERSION_VALUE,
-                AttributeKey.stringKey(DistroMetadata.RUNTIME_VERSION_FIELD), DistroMetadata.RUNTIME_VERSION_VALUE
+                AttributeKey.stringKey(DistroMetadata.RUNTIME_VERSION_FIELD), DistroMetadata.RUNTIME_VERSION_VALUE,
+                AttributeKey.stringKey(DistroMetadata.VARIANT_FIELD), DistroMetadata.VARIANT_AGENT
             ),
             resource.getAttributes()
         );

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -337,7 +337,7 @@ public final class OpenTelemetryConfiguration {
             SpanExporter spanExporter = getSpanExporter(logger);
             tracerProviderBuilder.addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build());
 
-            DistroMetadata.getMetadata().forEach(resourceAttributes::put);
+            DistroMetadata.getSDKMetadata().forEach(resourceAttributes::put);
             if (StringUtils.isNotEmpty(serviceName)) {
                 resourceAttributes.put(EnvironmentConfiguration.SERVICE_NAME_FIELD, serviceName);
             }


### PR DESCRIPTION
## Which problem is this PR solving?

- updates https://github.com/honeycombio/telemetry-team/issues/394
- but still need to pull the new attribute out on ingest

## Short description of the changes

- we cannot tell if people are using the sdk or the agent from current metadata
- deprecating previous function because it's a public API in a module we publish. it's unlikely anyone is using this class besides us, but technically it would be a breaking change.

