### PR TITLE
rel: 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # honeycomb-opentelemetry-java changelog
 
+## [1.4.1] - 2023-01-17
+
+### Fixes
+
+- fix: exception when initialized without API key (#378) | @vreynolds
+
+### Maintenance
+
+- maint(deps): bump mockito-core from 4.6.1 to 4.11.0 (#377)
+- maint(deps): bump junit-jupiter-api from 5.8.2 to 5.9.2 (#380)
+- Bump junit-bom from 5.9.0 to 5.9.1 (#359)
+- maint: additional metadata to diff sdk from agent (#379) | @vreynolds
+- chore: Dependabot fixes (#371) | @kentquirk
+- ci: update validate PR title workflow (#364) | @pkanal
+- ci: fix slack notify channel (#363) | @vreynolds
+- ci: validate PR title (#362) | @pkanal
+- maint: don't run extra jobs when releasing (#355) | @vreynolds
+
 ## [1.4.0] - 2022-10-28
 
 ### Maintenance

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,8 +2,6 @@
 
 1. Prep public docs PR with the new version (java-distro, otel-java-install, otel-java-run)
 
-1. Prep Onboarding docs PR with the new version (hound/DocsJava)
-
 1. Update the `project.version` in the root build.gradle file with the new release version. Snapshot version is one patch bump ahead of the new release (e.g. if we're releasing `1.0.0` then the corresponding snapshot would be `1.0.1`)
 
 1. Update the version in `DistroMetadata.java` with the new release version

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ allprojects {
     def tag = System.getenv("CIRCLE_TAG")
     if (tag != null && tag.startsWith("v")) {
         // circle tag means we're publishing a release version
-        project.version = "1.4.0"
+        project.version = "1.4.1"
     } else {
-        project.version = "1.4.1-SNAPSHOT"
+        project.version = "1.4.2-SNAPSHOT"
     }
 }
 

--- a/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
@@ -18,7 +18,7 @@ public class DistroMetadata {
      * with the version number and read it, but that isn't possible from the
      * Java agent.
      */
-    public static final String VERSION_VALUE = "1.4.0";
+    public static final String VERSION_VALUE = "1.4.1";
     public static final String VARIANT_FIELD = "honeycomb.distro.variant";
     public static final String VARIANT_AGENT = "agent";
     public static final String VARIANT_SDK = "sdk";


### PR DESCRIPTION
- release needful
- no longer need to update in-product docs since those are a link to latest release


![bring-it-on](https://user-images.githubusercontent.com/6738917/212990977-56e12b29-12dd-46fe-a102-0dccea8dd863.gif)
