### PR TITLE
maint: add smoke tests for grpc/http exporter protocols for agent only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,16 @@ smoke-tests/apps/spring-sdk.jar: build-artifacts/spring-sdk-$(project_version).j
 	@echo ""
 	cp $< $@
 
-smoke-agent-only: smoke-tests/apps/spring-agent-only.jar smoke-tests/apps/agent.jar smoke-tests/collector/data.json
-	cd smoke-tests && bats ./smoke-agent-only.bats --report-formatter junit --output ./
+.PHONY: smoke-agent-only
+smoke-agent-only: smoke-agent-grpc smoke-agent-http
+
+.PHONY: smoke-agent-grpc
+smoke-agent-grpc: smoke-tests/apps/spring-agent-only.jar smoke-tests/apps/agent.jar smoke-tests/collector/data.json
+	cd smoke-tests && bats ./smoke-agent-grpc.bats --report-formatter junit --output ./
+
+.PHONY: smoke-agent-http
+smoke-agent-http: smoke-tests/apps/spring-agent-only.jar smoke-tests/apps/agent.jar smoke-tests/collector/data.json
+	cd smoke-tests && bats ./smoke-agent-http.bats --report-formatter junit --output ./
 
 smoke-agent-manual: smoke-tests/apps/agent.jar smoke-tests/apps/spring-agent-manual.jar smoke-tests/collector/data.json
 	cd smoke-tests && bats ./smoke-agent-manual.bats --report-formatter junit --output ./

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -31,10 +31,24 @@ services:
     ports:
       - "127.0.0.1:5000:5000"
 
-  app-agent-only:
+  app-agent-grpc:
     <<: *app_base
     environment:
       <<: *env_base
+      HONEYCOMB_API_ENDPOINT: http://collector:4317
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+    volumes:
+      - "./apps/agent.jar:/agent.jar"
+      - "./apps/spring-agent-only.jar:/app.jar"
+    ports:
+      - "127.0.0.1:5002:5002"
+
+  app-agent-http:
+    <<: *app_base
+    environment:
+      <<: *env_base
+      HONEYCOMB_API_ENDPOINT: http://collector:4318
+      OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     volumes:
       - "./apps/agent.jar:/agent.jar"
       - "./apps/spring-agent-only.jar:/app.jar"

--- a/smoke-tests/smoke-agent-grpc.bats
+++ b/smoke-tests/smoke-agent-grpc.bats
@@ -2,7 +2,7 @@
 
 load test_helpers/utilities
 
-CONTAINER_NAME="smoke-agent-grpc"
+CONTAINER_NAME="app-agent-grpc"
 
 setup_file() {
 	echo "# 🚧" >&3

--- a/smoke-tests/smoke-agent-grpc.bats
+++ b/smoke-tests/smoke-agent-grpc.bats
@@ -2,7 +2,7 @@
 
 load test_helpers/utilities
 
-CONTAINER_NAME="smoke-agent-only"
+CONTAINER_NAME="smoke-agent-grpc"
 
 setup_file() {
 	echo "# 🚧" >&3

--- a/smoke-tests/smoke-agent-http.bats
+++ b/smoke-tests/smoke-agent-http.bats
@@ -2,7 +2,7 @@
 
 load test_helpers/utilities
 
-CONTAINER_NAME="smoke-agent-http"
+CONTAINER_NAME="app-agent-http"
 
 setup_file() {
 	echo "# 🚧" >&3

--- a/smoke-tests/smoke-agent-http.bats
+++ b/smoke-tests/smoke-agent-http.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+load test_helpers/utilities
+
+CONTAINER_NAME="smoke-agent-http"
+
+setup_file() {
+	echo "# 🚧" >&3
+	docker-compose up --detach collector ${CONTAINER_NAME}
+	wait_for_ready_app ${CONTAINER_NAME}
+	curl --silent "http://localhost:5002"
+	wait_for_traces
+}
+
+teardown_file() {
+  cp collector/data.json collector/data-results/data-${CONTAINER_NAME}.json
+	docker-compose stop ${CONTAINER_NAME}
+	docker-compose restart collector
+	wait_for_flush
+}
+
+# TESTS
+
+@test "Auto instrumentation produces a Spring controller span" {
+	result=$(span_names_for "io.opentelemetry.spring-webmvc-3.1")
+	assert_equal "$result" '"HelloController.index"'
+}
+
+@test "Auto instrumentation produces an incoming web request span" {
+	result=$(span_names_for "io.opentelemetry.tomcat-7.0")
+	assert_equal "$result" '"/"'
+}
+
+@test "Auto instrumentation emits metrics" {
+	wait_for_metrics 12
+	metric_names=$( metrics_received | jq ".scopeMetrics[].metrics[].name" | wc -l | awk '{ print $1}' )
+	[ "$metric_names" -ne 0 ]
+}

--- a/smoke-tests/smoke-agent-http.bats
+++ b/smoke-tests/smoke-agent-http.bats
@@ -31,8 +31,9 @@ teardown_file() {
 	assert_equal "$result" '"/"'
 }
 
-@test "Auto instrumentation emits metrics" {
-	wait_for_metrics 12
-	metric_names=$( metrics_received | jq ".scopeMetrics[].metrics[].name" | wc -l | awk '{ print $1}' )
-	[ "$metric_names" -ne 0 ]
-}
+# TODO add when http metrics is enabled
+# @test "Auto instrumentation emits metrics" {
+# 	wait_for_metrics 12
+# 	metric_names=$( metrics_received | jq ".scopeMetrics[].metrics[].name" | wc -l | awk '{ print $1}' )
+# 	[ "$metric_names" -ne 0 ]
+# }

--- a/smoke-tests/smoke-agent-only.bats
+++ b/smoke-tests/smoke-agent-only.bats
@@ -2,17 +2,19 @@
 
 load test_helpers/utilities
 
+CONTAINER_NAME="smoke-agent-only"
+
 setup_file() {
 	echo "# 🚧" >&3
-	docker-compose up --detach collector app-agent-only
-	wait_for_ready_app 'app-agent-only'
+	docker-compose up --detach collector ${CONTAINER_NAME}
+	wait_for_ready_app ${CONTAINER_NAME}
 	curl --silent "http://localhost:5002"
 	wait_for_traces
 }
 
 teardown_file() {
-    cp collector/data.json collector/data-results/data-agent-only.json
-	docker-compose stop app-agent-only
+  cp collector/data.json collector/data-results/data-${CONTAINER_NAME}.json
+	docker-compose stop ${CONTAINER_NAME}
 	docker-compose restart collector
 	wait_for_flush
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- closes #287 

## Short description of the changes

- add smoke tests for the app using only the java agent, similar to the tests for the SDK, for grpc and http/protobuf protocols
- there is a TODO added into the http test, as metrics are not currently available with http/protobuf protocol (see #293)

