### PR TITLE
maint: bump otel to 1.22.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry         : "1.19.0",
-                opentelemetryJavaagent: "1.19.1",
+                opentelemetry         : "1.22.0",
+                opentelemetryJavaagent: "1.22.1",
                 bytebuddy             : "1.10.18",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"

--- a/gradle/shadow.gradle
+++ b/gradle/shadow.gradle
@@ -5,7 +5,11 @@ ext.relocatePackages = { shadowJar ->
   shadowJar.relocate 'java.util.logging.Logger', 'io.opentelemetry.javaagent.bootstrap.PatchLogger'
 
   // rewrite library instrumentation dependencies
-  shadowJar.relocate "io.opentelemetry.instrumentation", "io.opentelemetry.javaagent.shaded.instrumentation"
+  shadowJar.relocate("io.opentelemetry.instrumentation", "io.opentelemetry.javaagent.shaded.instrumentation") {
+    // Exclude resource providers since they live in the agent class loader
+    exclude("io.opentelemetry.instrumentation.resources.*")
+    exclude("io.opentelemetry.instrumentation.spring.resources.*")
+  }
 
   // relocate OpenTelemetry API usage
   shadowJar.relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -8,11 +8,11 @@ description = 'Honeycomb SDK for manually configuring OpenTelemetry instrumentat
 
 dependencies {
     api "io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}"
-    api "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:${versions.opentelemetryJavaagentAlpha}"
+    api "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:${versions.opentelemetryJavaagent}"
 
     implementation "io.opentelemetry:opentelemetry-exporter-logging:${versions.opentelemetry}"
     implementation "io.opentelemetry:opentelemetry-exporter-otlp:${versions.opentelemetry}"
-    implementation "io.opentelemetry:opentelemetry-sdk-extension-resources:${versions.opentelemetry}"
+    implementation "io.opentelemetry.instrumentation:opentelemetry-resources:${versions.opentelemetryJavaagentAlpha}"
 
     implementation 'io.grpc:grpc-netty-shaded:1.50.2'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -1,7 +1,6 @@
 package io.honeycomb.opentelemetry;
 
 import com.google.common.base.Preconditions;
-
 import io.honeycomb.opentelemetry.sdk.trace.samplers.DeterministicTraceSampler;
 import io.honeycomb.opentelemetry.sdk.trace.spanprocessors.BaggageSpanProcessor;
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -17,8 +16,8 @@ import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
-import io.opentelemetry.sdk.extension.resources.OsResource;
-import io.opentelemetry.sdk.extension.resources.ProcessRuntimeResource;
+import io.opentelemetry.instrumentation.resources.OsResource;
+import io.opentelemetry.instrumentation.resources.ProcessRuntimeResource;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -35,8 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import static io.honeycomb.opentelemetry.EnvironmentConfiguration.isPresent;
 import static io.honeycomb.opentelemetry.EnvironmentConfiguration.isLegacyKey;
+import static io.honeycomb.opentelemetry.EnvironmentConfiguration.isPresent;
 
 /**
  * This class exists to make it easier and more intuitive to use Honeycomb with OpenTelemetry.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- bump to latest upstream agent version which includes auto-instrumented [JMX metrics](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics/javaagent#jmx-metric-insight)

## Short description of the changes

- a few things moved around

