### PR TITLE
maint: upgrade otel java agent to 1.23.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
     ext {
         versions = [
                 opentelemetry         : "1.23.1",
-                opentelemetryJavaagent: "1.22.1",
+                opentelemetryJavaagent: "1.23.0",
                 bytebuddy             : "1.10.18",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"

--- a/smoke-tests/smoke-agent-grpc.bats
+++ b/smoke-tests/smoke-agent-grpc.bats
@@ -28,7 +28,7 @@ teardown_file() {
 
 @test "Auto instrumentation produces an incoming web request span" {
 	result=$(span_names_for "io.opentelemetry.tomcat-7.0")
-	assert_equal "$result" '"/"'
+	assert_equal "$result" '"GET /"'
 }
 
 @test "Auto instrumentation emits metrics" {

--- a/smoke-tests/smoke-agent-http.bats
+++ b/smoke-tests/smoke-agent-http.bats
@@ -28,7 +28,7 @@ teardown_file() {
 
 @test "Auto instrumentation produces an incoming web request span" {
 	result=$(span_names_for "io.opentelemetry.tomcat-7.0")
-	assert_equal "$result" '"/"'
+	assert_equal "$result" '"GET /"'
 }
 
 # TODO add when http metrics is enabled

--- a/smoke-tests/smoke-agent-manual.bats
+++ b/smoke-tests/smoke-agent-manual.bats
@@ -26,7 +26,7 @@ teardown_file() {
 
 @test "Auto instrumentation produces an incoming web request span" {
 	result=$(span_names_for "io.opentelemetry.tomcat-7.0")
-	assert_equal "$result" '"/"'
+	assert_equal "$result" '"GET /"'
 }
 
 @test "Manual instrumentation produces span from @WithSpan annotation" {


### PR DESCRIPTION
## Which problem is this PR solving?

- supersedes #396 

## Short description of the changes

- upgrade otel java agent to 1.23.0
- update smoke tests - http spans now include method in name

## How to verify this has the expected result

smoke tests pass, see span names for auto-instrumented http spans include `GET` (now `GET /` instead of the previous `/`)
