### PR TITLE
docs: fix ci status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Honeycomb OpenTelemetry Distro for Java
 
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/honeycomb-opentelemetry-java)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
-[![CircleCI](https://circleci.com/gh/honeycombio/honeycomb-opentelemetry-java.svg?style=shield&circle-token=e2f4c30919ecbdbfb095415a6f4114a03dc491a0)](https://circleci.com/gh/honeycombio/honeycomb-opentelemetry-java)
+[![CircleCI](https://circleci.com/gh/honeycombio/honeycomb-opentelemetry-java.svg?style=shield)](https://circleci.com/gh/honeycombio/honeycomb-opentelemetry-java)
 [![Maven](https://img.shields.io/maven-central/v/io.honeycomb/honeycomb-opentelemetry-javaagent)](https://mvnrepository.com/artifact/io.honeycomb/honeycomb-opentelemetry-javaagent)
 
 This is Honeycomb's distribution of OpenTelemetry for Java.


### PR DESCRIPTION
## Which problem is this PR solving?

CI status badge does not render on the README

## Short description of the changes

We must've revoked the api token in circle at some point, so badge stopped showing up on the readme. We shouldn't need the api token anyway, because it's a public repo.

To verify, check this link: https://circleci.com/gh/honeycombio/honeycomb-opentelemetry-java.svg?style=shield

