### PR TITLE
maint(deps): bump versions.opentelemetryJavaagent from 1.23.0 to 1.24.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
     ext {
         versions = [
                 opentelemetry         : "1.24.0",
-                opentelemetryJavaagent: "1.23.0",
+                opentelemetryJavaagent: "1.24.0",
                 bytebuddy             : "1.10.18",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"


### PR DESCRIPTION
## Short description of the changes

Supersedes #405 

Bumps `versions.opentelemetryJavaagent` from 1.23.0 to 1.24.0.
Updates `io.opentelemetry.javaagent:opentelemetry-javaagent` from 1.23.0 to 1.24.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases">io.opentelemetry.javaagent:opentelemetry-javaagent's releases</a>.</em></p>
<blockquote>
<h2>Version 1.24.0</h2>
<p>This release targets the OpenTelemetry SDK 1.24.0.</p>
<p>Note that many artifacts have the <code>-alpha</code> suffix attached to their version number, reflecting that they are still alpha quality and will continue to have breaking changes. Please see the <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/VERSIONING.md#opentelemetry-java-instrumentation-versioning">VERSIONING.md</a> for more details.</p>
<h3>Migration notes</h3>
<h3>🌟 New javaagent instrumentation</h3>
<ul>
<li>Add Apache Pulsar client instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5926">#5926</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7999">#7999</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7943">#7943</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8007">#8007</a>)</li>
<li>Add Jodd-Http instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7868">#7868</a>)</li>
</ul>
<h3>🌟 New library instrumentation</h3>
<ul>
<li>Add Ktor client instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7982">#7982</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7997">#7997</a>)</li>
<li>Add Spring Webflux server instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7899">#7899</a>)</li>
</ul>
<h3>📈 Enhancements</h3>
<ul>
<li>Implement <code>messaging.kafka.*</code> attributes spec (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7824">#7824</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7860">#7860</a>)</li>
<li>Make RxJava2 instrumentation Android-friendly (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7895">#7895</a>)</li>
<li>Support more semantic convention for RocketMQ trace (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7871">#7871</a>)</li>
<li>Instrumenting cassandra executeReactive method (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/6441">#6441</a>)</li>
<li>Make the OpenTelemetry Logback appender work with GraalVM native images (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7989">#7989</a>)</li>
<li>Add baggage to Logback MDC; controlled by a configuration flag (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7892">#7892</a>)</li>
<li>Make the Spring Boot autoconfigure module work with Spring Boot 3 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8028">#8028</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8051">#8051</a>)</li>
</ul>
<h3>🛠️ Bug fixes</h3>
<ul>
<li>Handle JMX MBean attributes with embedded dots (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7841">#7841</a>)</li>
<li>Fix <code>ClassCastException</code> when using <code>-Dotel.jmx.target.system=tomcat</code> (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7884">#7884</a>)</li>
<li>Fix NPE in the AWS SDK 2 instrumentation when request instrumentation is suppressed (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7953">#7953</a>)</li>
<li>Fix Kotlin coroutine context propagation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7879">#7879</a>)</li>
<li>Fix the JAX-RS annotation instrumentation on Open Liberty (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7890">#7890</a>)</li>
<li>Fix an <code>AbstractMethodError</code> in the Logback instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7967">#7967</a>)</li>
<li>Fix NPE in the RabbitMQ instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8021">#8021</a>)</li>
<li>Fix JMX metrics usage examples (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7877">#7877</a>)</li>
</ul>
<h3>🧰 Tooling</h3>
<ul>
<li>Remove deprecated <code>instrumentation-api-semconv</code> code (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7838">#7838</a>)</li>
<li>Look up helper class bytes when they are needed (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7839">#7839</a>)</li>
<li>Run smoke tests using Open Liberty 21.0.0.12 and 22.0.0.12 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7878">#7878</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7857">#7857</a>)</li>
<li>Add additional groovy script classloaders to ignore list. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7460">#7460</a>)</li>
<li>Make AggregationTemporality configurable for <code>OtlpInMemoryMetricExporter</code> in the <code>agent-for-testing</code> module (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7904">#7904</a>)</li>
<li>Upgrade to gradle 8.0.2 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7910">#7910</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7978"> 7978</a>)</li>
<li>Replace the test-sets plugin with Gradle test suites (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7930">#7930</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7933">#7933</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7932">#7932</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7931">#7931</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7929">#7929</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7946">#7946</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7945">#7945</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7944">#7944</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7943">#7943</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7942">#7942</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7928">#7928</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7951">#7951</a>)</li>
<li>Add a utility for tracking HTTP resends (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7986">#7986</a>)</li>
<li>Remove deprecated <code>messaging.url</code> attribute from messaging getter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8008">#8008</a>)</li>
<li>Add protocol name&amp;version to net attribute getters (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7994">#7994</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md">io.opentelemetry.javaagent:opentelemetry-javaagent's changelog</a>.</em></p>
<blockquote>
<h2>Version 1.24.0 (2023-03-15)</h2>
<h3>Migration notes</h3>
<h3>🌟 New javaagent instrumentation</h3>
<ul>
<li>Add Apache Pulsar client instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5926">#5926</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7999">#7999</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7943">#7943</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8007">#8007</a>)</li>
<li>Add Jodd-Http instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7868">#7868</a>)</li>
</ul>
<h3>🌟 New library instrumentation</h3>
<ul>
<li>Add Ktor client instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7982">#7982</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7997">#7997</a>)</li>
<li>Add Spring Webflux server instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7899">#7899</a>)</li>
</ul>
<h3>📈 Enhancements</h3>
<ul>
<li>Implement <code>messaging.kafka.*</code> attributes spec
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7824">#7824</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7860">#7860</a>)</li>
<li>Make RxJava2 instrumentation Android-friendly
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7895">#7895</a>)</li>
<li>Support more semantic convention for RocketMQ trace
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7871">#7871</a>)</li>
<li>Instrumenting cassandra executeReactive method
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/6441">#6441</a>)</li>
<li>Make the OpenTelemetry Logback appender work with GraalVM native images
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7989">#7989</a>)</li>
<li>Add baggage to Logback MDC; controlled by a configuration flag
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7892">#7892</a>)</li>
<li>Make the Spring Boot autoconfigure module work with Spring Boot 3
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8028">#8028</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8051">#8051</a>)</li>
</ul>
<h3>🛠️ Bug fixes</h3>
<ul>
<li>Handle JMX MBean attributes with embedded dots
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7841">#7841</a>)</li>
<li>Fix <code>ClassCastException</code> when using <code>-Dotel.jmx.target.system=tomcat</code>
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7884">#7884</a>)</li>
<li>Fix NPE in the AWS SDK 2 instrumentation when request instrumentation is suppressed
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7953">#7953</a>)</li>
<li>Fix Kotlin coroutine context propagation</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/ce8c7fa08a37d29bef64ec98c5da6c93baf1ebd9"><code>ce8c7fa</code></a> [release/v1.24.x] Prepare release 1.24.0 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8054">#8054</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/65bf28ff16fe64c5b8988d5b00db6736fcb7e78a"><code>65bf28f</code></a> Prepare changelog for v1.24.0 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8039">#8039</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/2cbfec8ac2f4cb9b058459be0b521c9eecc419dd"><code>2cbfec8</code></a> Fix spring boot 3 webmvc autoconfiguration (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8051">#8051</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/9ebfe03e7260ef33d99d0d3438fa0fbdb0a9df9e"><code>9ebfe03</code></a> Use timer for pulsar consumer spans (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8050">#8050</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/41c2dfdf7f06ed178cc585be6c5d6ae7fcd896a9"><code>41c2dfd</code></a> Bump byteBuddyVersion from 1.14.1 to 1.14.2 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8044">#8044</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/09577f97ffc0ca9f703386e12afbd018d12a2935"><code>09577f9</code></a> Bump net.bytebuddy:byte-buddy-dep from 1.14.1 to 1.14.2 in /examples/distro (...</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/331a962e927415fcee894c2b3e2bb18316b1eeab"><code>331a962</code></a> Bump com.diffplug.spotless from 6.16.0 to 6.17.0 in /benchmark-overhead (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8049">#8049</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/295a6dded5a92d4e0f484056a5736f44dfc0ad3d"><code>295a6dd</code></a> Bump com.diffplug.spotless from 6.16.0 to 6.17.0 in /examples/extension (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8048">#8048</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/9064e4a672e951b5b337f4cf1ae206fcc48fe4da"><code>9064e4a</code></a> Bump com.diffplug.spotless:spotless-plugin-gradle from 6.16.0 to 6.17.0 in /e...</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/acdfea28535b1d733a6e850fca83285a6561d1b4"><code>acdfea2</code></a> Bump com.diffplug.spotless:spotless-plugin-gradle from 6.16.0 to 6.17.0 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8045">#8045</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/compare/v1.23.0...v1.24.0">compare view</a></li>
</ul>
</details>
<br />

Updates `io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations` from 1.23.0 to 1.24.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases">io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations's releases</a>.</em></p>
<blockquote>
<h2>Version 1.24.0</h2>
<p>This release targets the OpenTelemetry SDK 1.24.0.</p>
<p>Note that many artifacts have the <code>-alpha</code> suffix attached to their version number, reflecting that they are still alpha quality and will continue to have breaking changes. Please see the <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/VERSIONING.md#opentelemetry-java-instrumentation-versioning">VERSIONING.md</a> for more details.</p>
<h3>Migration notes</h3>
<h3>🌟 New javaagent instrumentation</h3>
<ul>
<li>Add Apache Pulsar client instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5926">#5926</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7999">#7999</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7943">#7943</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8007">#8007</a>)</li>
<li>Add Jodd-Http instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7868">#7868</a>)</li>
</ul>
<h3>🌟 New library instrumentation</h3>
<ul>
<li>Add Ktor client instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7982">#7982</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7997">#7997</a>)</li>
<li>Add Spring Webflux server instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7899">#7899</a>)</li>
</ul>
<h3>📈 Enhancements</h3>
<ul>
<li>Implement <code>messaging.kafka.*</code> attributes spec (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7824">#7824</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7860">#7860</a>)</li>
<li>Make RxJava2 instrumentation Android-friendly (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7895">#7895</a>)</li>
<li>Support more semantic convention for RocketMQ trace (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7871">#7871</a>)</li>
<li>Instrumenting cassandra executeReactive method (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/6441">#6441</a>)</li>
<li>Make the OpenTelemetry Logback appender work with GraalVM native images (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7989">#7989</a>)</li>
<li>Add baggage to Logback MDC; controlled by a configuration flag (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7892">#7892</a>)</li>
<li>Make the Spring Boot autoconfigure module work with Spring Boot 3 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8028">#8028</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8051">#8051</a>)</li>
</ul>
<h3>🛠️ Bug fixes</h3>
<ul>
<li>Handle JMX MBean attributes with embedded dots (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7841">#7841</a>)</li>
<li>Fix <code>ClassCastException</code> when using <code>-Dotel.jmx.target.system=tomcat</code> (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7884">#7884</a>)</li>
<li>Fix NPE in the AWS SDK 2 instrumentation when request instrumentation is suppressed (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7953">#7953</a>)</li>
<li>Fix Kotlin coroutine context propagation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7879">#7879</a>)</li>
<li>Fix the JAX-RS annotation instrumentation on Open Liberty (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7890">#7890</a>)</li>
<li>Fix an <code>AbstractMethodError</code> in the Logback instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7967">#7967</a>)</li>
<li>Fix NPE in the RabbitMQ instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8021">#8021</a>)</li>
<li>Fix JMX metrics usage examples (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7877">#7877</a>)</li>
</ul>
<h3>🧰 Tooling</h3>
<ul>
<li>Remove deprecated <code>instrumentation-api-semconv</code> code (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7838">#7838</a>)</li>
<li>Look up helper class bytes when they are needed (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7839">#7839</a>)</li>
<li>Run smoke tests using Open Liberty 21.0.0.12 and 22.0.0.12 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7878">#7878</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7857">#7857</a>)</li>
<li>Add additional groovy script classloaders to ignore list. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7460">#7460</a>)</li>
<li>Make AggregationTemporality configurable for <code>OtlpInMemoryMetricExporter</code> in the <code>agent-for-testing</code> module (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7904">#7904</a>)</li>
<li>Upgrade to gradle 8.0.2 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7910">#7910</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7978"> 7978</a>)</li>
<li>Replace the test-sets plugin with Gradle test suites (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7930">#7930</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7933">#7933</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7932">#7932</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7931">#7931</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7929">#7929</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7946">#7946</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7945">#7945</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7944">#7944</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7943">#7943</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7942">#7942</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7928">#7928</a>, <a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7951">#7951</a>)</li>
<li>Add a utility for tracking HTTP resends (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7986">#7986</a>)</li>
<li>Remove deprecated <code>messaging.url</code> attribute from messaging getter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8008">#8008</a>)</li>
<li>Add protocol name&amp;version to net attribute getters (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7994">#7994</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md">io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations's changelog</a>.</em></p>
<blockquote>
<h2>Version 1.24.0 (2023-03-15)</h2>
<h3>Migration notes</h3>
<h3>🌟 New javaagent instrumentation</h3>
<ul>
<li>Add Apache Pulsar client instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5926">#5926</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7999">#7999</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7943">#7943</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8007">#8007</a>)</li>
<li>Add Jodd-Http instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7868">#7868</a>)</li>
</ul>
<h3>🌟 New library instrumentation</h3>
<ul>
<li>Add Ktor client instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7982">#7982</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7997">#7997</a>)</li>
<li>Add Spring Webflux server instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7899">#7899</a>)</li>
</ul>
<h3>📈 Enhancements</h3>
<ul>
<li>Implement <code>messaging.kafka.*</code> attributes spec
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7824">#7824</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7860">#7860</a>)</li>
<li>Make RxJava2 instrumentation Android-friendly
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7895">#7895</a>)</li>
<li>Support more semantic convention for RocketMQ trace
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7871">#7871</a>)</li>
<li>Instrumenting cassandra executeReactive method
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/6441">#6441</a>)</li>
<li>Make the OpenTelemetry Logback appender work with GraalVM native images
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7989">#7989</a>)</li>
<li>Add baggage to Logback MDC; controlled by a configuration flag
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7892">#7892</a>)</li>
<li>Make the Spring Boot autoconfigure module work with Spring Boot 3
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8028">#8028</a>,
<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8051">#8051</a>)</li>
</ul>
<h3>🛠️ Bug fixes</h3>
<ul>
<li>Handle JMX MBean attributes with embedded dots
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7841">#7841</a>)</li>
<li>Fix <code>ClassCastException</code> when using <code>-Dotel.jmx.target.system=tomcat</code>
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7884">#7884</a>)</li>
<li>Fix NPE in the AWS SDK 2 instrumentation when request instrumentation is suppressed
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7953">#7953</a>)</li>
<li>Fix Kotlin coroutine context propagation</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/ce8c7fa08a37d29bef64ec98c5da6c93baf1ebd9"><code>ce8c7fa</code></a> [release/v1.24.x] Prepare release 1.24.0 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8054">#8054</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/65bf28ff16fe64c5b8988d5b00db6736fcb7e78a"><code>65bf28f</code></a> Prepare changelog for v1.24.0 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8039">#8039</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/2cbfec8ac2f4cb9b058459be0b521c9eecc419dd"><code>2cbfec8</code></a> Fix spring boot 3 webmvc autoconfiguration (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8051">#8051</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/9ebfe03e7260ef33d99d0d3438fa0fbdb0a9df9e"><code>9ebfe03</code></a> Use timer for pulsar consumer spans (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8050">#8050</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/41c2dfdf7f06ed178cc585be6c5d6ae7fcd896a9"><code>41c2dfd</code></a> Bump byteBuddyVersion from 1.14.1 to 1.14.2 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8044">#8044</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/09577f97ffc0ca9f703386e12afbd018d12a2935"><code>09577f9</code></a> Bump net.bytebuddy:byte-buddy-dep from 1.14.1 to 1.14.2 in /examples/distro (...</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/331a962e927415fcee894c2b3e2bb18316b1eeab"><code>331a962</code></a> Bump com.diffplug.spotless from 6.16.0 to 6.17.0 in /benchmark-overhead (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8049">#8049</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/295a6dded5a92d4e0f484056a5736f44dfc0ad3d"><code>295a6dd</code></a> Bump com.diffplug.spotless from 6.16.0 to 6.17.0 in /examples/extension (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8048">#8048</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/9064e4a672e951b5b337f4cf1ae206fcc48fe4da"><code>9064e4a</code></a> Bump com.diffplug.spotless:spotless-plugin-gradle from 6.16.0 to 6.17.0 in /e...</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/acdfea28535b1d733a6e850fca83285a6561d1b4"><code>acdfea2</code></a> Bump com.diffplug.spotless:spotless-plugin-gradle from 6.16.0 to 6.17.0 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8045">#8045</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/compare/v1.23.0...v1.24.0">compare view</a></li>
</ul>
</details>
<br />

