### PR TITLE
maint: update docker image and collector version in smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,13 +132,7 @@ matrix_executors: &matrix_executors
   parameters:
     executor:
       - name: gradle/default
-        tag: "8.0"
-      - name: gradle/default
-        tag: "11.0"
-      - name: gradle/default
         tag: "17.0"
-      - name: gradle/default
-        tag: "18.0"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 
   smoke_test:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2004:2023.04.2
     steps:
       - checkout
       - attach_workspace:
@@ -47,7 +47,7 @@ jobs:
             bats --version
       - run:
           name: Smoke Test
-          command: make smoke
+          command: make smoke-sdk-grpc
       - store_test_results:
           path: ./smoke-tests/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
             bats --version
       - run:
           name: Smoke Test
-          command: make smoke-sdk-grpc
+          command: make smoke
       - store_test_results:
           path: ./smoke-tests/
       - store_artifacts:
@@ -132,7 +132,13 @@ matrix_executors: &matrix_executors
   parameters:
     executor:
       - name: gradle/default
+        tag: "8.0"
+      - name: gradle/default
+        tag: "11.0"
+      - name: gradle/default
         tag: "17.0"
+      - name: gradle/default
+        tag: "18.0"
 
 workflows:
   version: 2

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -15,7 +15,7 @@ x-app-base: &app_base
 
 services:
   collector:
-    image: otel/opentelemetry-collector:0.52.0
+    image: otel/opentelemetry-collector:0.69.0
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - "./collector/otel-collector-config.yaml:/etc/otel-collector-config.yaml"

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -8,7 +8,7 @@ x-env-base: &env_base
   OTEL_METRIC_EXPORT_INTERVAL: 1000
 
 x-app-base: &app_base
-  image: eclipse-temurin:17
+  image: openjdk:17-jdk-alpine
   command: "java -javaagent:/agent.jar -jar /app.jar"
   depends_on:
     - collector

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -8,7 +8,7 @@ x-env-base: &env_base
   OTEL_METRIC_EXPORT_INTERVAL: 1000
 
 x-app-base: &app_base
-  image: eclipse-temurin:17-jre
+  image: eclipse-temurin:17
   command: "java -javaagent:/agent.jar -jar /app.jar"
   depends_on:
     - collector

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -8,7 +8,7 @@ x-env-base: &env_base
   OTEL_METRIC_EXPORT_INTERVAL: 1000
 
 x-app-base: &app_base
-  image: openjdk:17-jdk-alpine
+  image: eclipse-temurin:17-jdk-alpine
   command: "java -javaagent:/agent.jar -jar /app.jar"
   depends_on:
     - collector

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -8,7 +8,7 @@ x-env-base: &env_base
   OTEL_METRIC_EXPORT_INTERVAL: 1000
 
 x-app-base: &app_base
-  image: openjdk:17-jdk-alpine
+  image: eclipse-temurin:17-jdk
   command: "java -javaagent:/agent.jar -jar /app.jar"
   depends_on:
     - collector

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -8,7 +8,7 @@ x-env-base: &env_base
   OTEL_METRIC_EXPORT_INTERVAL: 1000
 
 x-app-base: &app_base
-  image: eclipse-temurin:17-jdk-alpine
+  image: eclipse-temurin:17-jdk-jammy
   command: "java -javaagent:/agent.jar -jar /app.jar"
   depends_on:
     - collector

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -8,7 +8,7 @@ x-env-base: &env_base
   OTEL_METRIC_EXPORT_INTERVAL: 1000
 
 x-app-base: &app_base
-  image: eclipse-temurin:17-jdk
+  image: eclipse-temurin:17-jre
   command: "java -javaagent:/agent.jar -jar /app.jar"
   depends_on:
     - collector


### PR DESCRIPTION
## Which problem is this PR solving?

- trying to run smoke tests locally using `openjdk:17-jdk-alpine` results in error `no matching manifest for linux/arm64/v8 in the manifest list entries`

## Short description of the changes

- swap out [openjdk](https://hub.docker.com/_/openjdk) for [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin). I could just use a non-alpine image, but it also shows this is a deprecated image (see [here](https://github.com/docker-library/openjdk/issues/505)) so figured I'd swap out now.
- updated the ubuntu machine image in circle to work with the new jdk image
- updated collector version to 0.69. The file exporter changed in v0.70.0 and will need a few other changes to work for us, but this is at least newer than the version we were using.
