### PR TITLE
rel: Prepeare v1.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # honeycomb-opentelemetry-java changelog
 
+## [1.5.1] - 2023-06-06
+
+### Maintenance
+
+- maint: update docker image and collector version in smoke tests (#422) | @JamieDanielson
+- maint(deps): bump io.grpc:grpc-netty-shaded from 1.53.0 to 1.55.1 (#423) | @dependabot
+- maint(deps): bump versions.opentelemetry from 1.25.0 to 1.26.0 (#425) | @dependabot
+- maint(deps): bump versions.opentelemetryJavaagent from 1.25.0 to 1.26.0 (#424) | @dependabot
+- maint(deps): bump org.junit:junit-bom from 5.9.2 to 5.9.3 (#420) | @dependabot
+
 ## [1.5.0] - 2023-04-28
 
 ### Maintenance

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It makes getting started with OpenTelemetry and Honeycomb easier!
 
 Latest release built with:
 
-- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.25.0) version 1.25.0
-- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.25.0) version 1.25.0
+- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.26.0) version 1.26.0
+- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.27.0) version 1.26.0
 
 ## Getting Started
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ allprojects {
     def tag = System.getenv("CIRCLE_TAG")
     if (tag != null && tag.startsWith("v")) {
         // circle tag means we're publishing a release version
-        project.version = "1.5.0"
+        project.version = "1.5.1"
     } else {
-        project.version = "1.5.1-SNAPSHOT"
+        project.version = "1.5.2-SNAPSHOT"
     }
 }
 

--- a/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
@@ -18,7 +18,7 @@ public class DistroMetadata {
      * with the version number and read it, but that isn't possible from the
      * Java agent.
      */
-    public static final String VERSION_VALUE = "1.5.0";
+    public static final String VERSION_VALUE = "1.5.1";
     public static final String VARIANT_FIELD = "honeycomb.distro.variant";
     public static final String VARIANT_AGENT = "agent";
     public static final String VARIANT_SDK = "sdk";


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the v1.5.1 release.

## Short description of the changes
- Adds changelog entry
- Updates version to 1.5.1, next snapshot to 1.5.2
- Update README with new upstream OTel versions

