### PR TITLE
rel: prep release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # honeycomb-opentelemetry-java changelog
 
+## [1.5.2] - 2023-06-21
+
+### Maintenance
+
+- maint(deps): bump versions.opentelemetry from 1.26.0 to 1.27.0 (#428)
+- maint(deps): bump versions.opentelemetryJavaagent from 1.26.0 to 1.27.0 (#431)
+- maint(deps): bump org.junit.jupiter:junit-jupiter-api from 5.9.2 to 5.9.3 (#429)
+- maint(deps): bump io.grpc:grpc-netty-shaded from 1.55.1 to 1.56.0 (#430)
+- maint: update licenses for new otel-java versions (#432)| [@JamieDanielson](https://github.com/JamieDanielson)
+
 ## [1.5.1] - 2023-06-06
 
 ### Maintenance

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It makes getting started with OpenTelemetry and Honeycomb easier!
 
 Latest release built with:
 
-- [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.26.0) version 1.26.0
-- [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.27.0) version 1.26.0
+- [OpenTelemetry v1.27.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.27.0)
+- [OpenTelemetry Java Agent v1.27.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.27.0)
 
 ## Getting Started
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,12 +2,13 @@
 
 1. Prep public docs PR with the new version in data file `/honeycomb-opentelemetry-java/release.json`
 
-1. Run `./gradlew generateLicenseReport` to ensure all project dependency licenses are correclty represented in this repository. If there are any changes, submit PR to update licenses.
+1. Run `./gradlew generateLicenseReport` to ensure all project dependency licenses are correctly represented in this repository. If there are any changes, submit PR to update licenses.
 
 1. Update the `project.version` in the root build.gradle file with the new release version. Snapshot version is one patch bump ahead of the new release (e.g. if we're releasing `1.0.0` then the corresponding snapshot would be `1.0.1`)
 
 1. Update the version in `DistroMetadata.java` with the new release version
-    - When updating the OTel Agent/SDK version, update the OTLP version header in `DistroMetadata.java`
+    - When updating the OTel Agent/SDK version, update the OTLP version header as needed in `DistroMetadata.java`
+    - This can be found in upstream repo `/dependencyManagement/build.gradle.kts`
 
 1. Update the Changelog
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,6 +10,8 @@
     - When updating the OTel Agent/SDK version, update the OTLP version header as needed in `DistroMetadata.java`
     - This can be found in upstream repo `/dependencyManagement/build.gradle.kts`
 
+1. If OTLP proto version changes in previous step, update tests in `EnvironmentConfigurationTest.java`
+
 1. Update the Changelog
 
 1. If the new release updates the OpenTelemetry SDK and/or agent versions, update the `Latest release built with` section in the [README](./README.md).

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ allprojects {
     def tag = System.getenv("CIRCLE_TAG")
     if (tag != null && tag.startsWith("v")) {
         // circle tag means we're publishing a release version
-        project.version = "1.5.1"
+        project.version = "1.5.2"
     } else {
-        project.version = "1.5.2-SNAPSHOT"
+        project.version = "1.5.3-SNAPSHOT"
     }
 }
 

--- a/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
@@ -18,7 +18,7 @@ public class DistroMetadata {
      * with the version number and read it, but that isn't possible from the
      * Java agent.
      */
-    public static final String VERSION_VALUE = "1.5.1";
+    public static final String VERSION_VALUE = "1.5.2";
     public static final String VARIANT_FIELD = "honeycomb.distro.variant";
     public static final String VARIANT_AGENT = "agent";
     public static final String VARIANT_SDK = "sdk";
@@ -26,7 +26,7 @@ public class DistroMetadata {
     public static final String RUNTIME_VERSION_VALUE = System.getProperty("java.runtime.version");
 
     public static final String OTLP_PROTO_VERSION_HEADER = "x-otlp-version";
-    public static final String OTLP_PROTO_VERSION_VALUE = "0.19.0";
+    public static final String OTLP_PROTO_VERSION_VALUE = "0.20.0";
 
     /**
      * Get Metadata as a map of strings to strings.

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -139,7 +139,7 @@ public class EnvironmentConfigurationTest {
 
         EnvironmentConfiguration.enableOTLPTraces();
         Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.traces.endpoint"));
-        Assertions.assertEquals("x-otlp-version=0.19.0,X-Honeycomb-Team=11111111111111111111111111111111,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.traces.headers"));
+        Assertions.assertEquals("x-otlp-version=0.20.0,X-Honeycomb-Team=11111111111111111111111111111111,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.traces.headers"));
     }
 
     @Test
@@ -154,7 +154,7 @@ public class EnvironmentConfigurationTest {
 
         EnvironmentConfiguration.enableOTLPTraces();
         Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.traces.endpoint"));
-        Assertions.assertEquals("x-otlp-version=0.19.0,X-Honeycomb-Team=specialenvkey", System.getProperty("otel.exporter.otlp.traces.headers"));
+        Assertions.assertEquals("x-otlp-version=0.20.0,X-Honeycomb-Team=specialenvkey", System.getProperty("otel.exporter.otlp.traces.headers"));
     }
 
     @Test
@@ -165,7 +165,7 @@ public class EnvironmentConfigurationTest {
         EnvironmentConfiguration.enableOTLPMetrics();
         Assertions.assertEquals("otlp", System.getProperty("otel.metrics.exporter"));
         Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.metrics.endpoint"));
-        Assertions.assertEquals("x-otlp-version=0.19.0,X-Honeycomb-Team=my-key,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
+        Assertions.assertEquals("x-otlp-version=0.20.0,X-Honeycomb-Team=my-key,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
     }
 
     // make sure OtlpTraces logic doesn't bleed into metrics; dataset still needed
@@ -177,7 +177,7 @@ public class EnvironmentConfigurationTest {
         EnvironmentConfiguration.enableOTLPMetrics();
         Assertions.assertEquals("otlp", System.getProperty("otel.metrics.exporter"));
         Assertions.assertEquals("https://api.honeycomb.io:443", System.getProperty("otel.exporter.otlp.metrics.endpoint"));
-        Assertions.assertEquals("x-otlp-version=0.19.0,X-Honeycomb-Team=11111111111111111111111111111111,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
+        Assertions.assertEquals("x-otlp-version=0.20.0,X-Honeycomb-Team=11111111111111111111111111111111,X-Honeycomb-Dataset=my-dataset", System.getProperty("otel.exporter.otlp.metrics.headers"));
     }
 
     @Test


### PR DESCRIPTION
## Which problem is this PR solving?

- release prep for v1.5.2

## Short description of the changes

- update releasing doc for how to find proto version in otel java, and how to update in tests
- update version in root build.gradle to 1.5.2
- update otel version to 1.27.0 and proto version to 0.20.0 in distrometadata
- update changelog for v1.5.2
- update readme with otel versions 1.27.0
- update test with new proto version

A docs PR has been prepped with the new release version, to be merged once this release is out.

