### PR TITLE
feat: add support for classic ingest keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 
   smoke_test:
     machine:
-      image: ubuntu-2004:2023.04.2
+      image: ubuntu-2204:2024.01.1
     steps:
       - checkout
       - attach_workspace:

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -181,7 +181,7 @@ public class EnvironmentConfiguration {
         return value != null && !value.isEmpty();
     }
 
-    public static boolean isLegacyKey(String key) {
+    public static boolean isClassicKey(String key) {
         if(!isPresent(key)) {
             return false;
         }
@@ -235,7 +235,7 @@ public class EnvironmentConfiguration {
         }
 
         // heads up: even if dataset is set, it will be ignored
-        if (isPresent(apiKey) && !isLegacyKey(apiKey) && isPresent(dataset)) {
+        if (isPresent(apiKey) && !isClassicKey(apiKey) && isPresent(dataset)) {
             if (isPresent(serviceName)) {
                 System.out.printf("WARN: Dataset is ignored in favor of service name. Data will be sent to service name: %s%n", serviceName);
             } else {
@@ -305,7 +305,7 @@ public class EnvironmentConfiguration {
         final Map<String, String> headers = new HashMap<String, String>();
         headers.put(DistroMetadata.OTLP_PROTO_VERSION_HEADER, DistroMetadata.OTLP_PROTO_VERSION_VALUE);
         headers.put(HONEYCOMB_TEAM_HEADER, apiKey);
-        if (isLegacyKey(apiKey)) {
+        if (isClassicKey(apiKey)) {
             // if the key is legacy, add dataset to the header
             if (isPresent(dataset)) {
                 headers.put(HONEYCOMB_DATASET_HEADER, dataset);

--- a/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/EnvironmentConfiguration.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -41,6 +42,9 @@ public class EnvironmentConfiguration {
 
     private static final Properties properties = loadPropertiesFromConfigFile();
     private static final String OTEL_AGENT_CONFIG_FILE = "otel.javaagent.configuration-file";
+
+    private static final Pattern CLASSIC_KEY_REGEX = Pattern.compile("^[a-f0-9]*$");
+    private static final Pattern INGEST_CLASSIC_KEY_REGEX = Pattern.compile("^hc[a-z]ic_[a-z0-9]*$");
 
     // OTLP exporter protocols
     public static final String OTEL_EXPORTER_OTLP_PROTOCOL = "OTEL_EXPORTER_OTLP_PROTOCOL";
@@ -178,8 +182,16 @@ public class EnvironmentConfiguration {
     }
 
     public static boolean isLegacyKey(String key) {
-        // legacy key has 32 characters
-        return isPresent(key) && key.length() == 32;
+        if(!isPresent(key)) {
+            return false;
+        }
+        else if(key.length() == 32) {
+            return CLASSIC_KEY_REGEX.matcher(key).matches();
+        }
+        else if(key.length() == 64) {
+            return INGEST_CLASSIC_KEY_REGEX.matcher(key).matches();
+        }
+        return false;
     }
 
     private static String readVariable(String key, String fallback) {

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -224,7 +224,7 @@ public class EnvironmentConfigurationTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("getIsLegacyKeyArguments")
     public void test_isLegacyKey(String name, String input, boolean expected) {
-        Assertions.assertEquals(EnvironmentConfiguration.isLegacyKey(input), expected);
+        Assertions.assertEquals(EnvironmentConfiguration.isClassicKey(input), expected);
     }
 
     private static Stream<Arguments> getIsLegacyKeyArguments() {

--- a/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/EnvironmentConfigurationTest.java
@@ -3,10 +3,14 @@ package io.honeycomb.opentelemetry;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 public class EnvironmentConfigurationTest {
 
@@ -215,5 +219,23 @@ public class EnvironmentConfigurationTest {
         } catch (Exception e) {
             Assertions.fail(e);
         }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getIsLegacyKeyArguments")
+    public void test_isLegacyKey(String name, String input, boolean expected) {
+        Assertions.assertEquals(EnvironmentConfiguration.isLegacyKey(input), expected);
+    }
+
+    private static Stream<Arguments> getIsLegacyKeyArguments() {
+        return Stream.of(
+            Arguments.of( "full ingest key string, non classic", "hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc", false),
+            Arguments.of( "ingest key id, non classic", "hcxik_01hqk4k20cjeh63wca8vva5stw", false),
+            Arguments.of( "full ingest key string,classic", "hcaic_1234567890123456789012345678901234567890123456789012345678", true),
+            Arguments.of( "ingest key id, classic", "hcaic_12345678901234567890123456", false),
+            Arguments.of( "v2 configuration key", "kgvSpPwegJshQkuowXReLD", false),
+            Arguments.of( "classic key", "12345678901234567890123456789012", true),
+            Arguments.of( "empty string", "", false)
+        );
     }
 }

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import static io.honeycomb.opentelemetry.EnvironmentConfiguration.isLegacyKey;
+import static io.honeycomb.opentelemetry.EnvironmentConfiguration.isClassicKey;
 import static io.honeycomb.opentelemetry.EnvironmentConfiguration.isPresent;
 
 /**
@@ -317,7 +317,7 @@ public final class OpenTelemetryConfiguration {
             }
 
             // heads up: even if dataset is set, it will be ignored
-            if (isPresent(tracesApiKey) && !isLegacyKey(tracesApiKey) && isPresent(tracesDataset)) {
+            if (isPresent(tracesApiKey) && !isClassicKey(tracesApiKey) && isPresent(tracesDataset)) {
                 if (isPresent(serviceName)) {
                     System.out.printf("WARN: Dataset is ignored in favor of service name. Data will be sent to service name: %s%n", serviceName);
                 } else {
@@ -379,7 +379,7 @@ public final class OpenTelemetryConfiguration {
                 headers.entrySet().forEach(entry -> builder.addHeader(entry.getKey(), entry.getValue()));
 
                 // if legacy key and missing dataset, warn on missing dataset
-                if (isLegacyKey(tracesApiKey) && !isPresent(tracesDataset)) {
+                if (isClassicKey(tracesApiKey) && !isPresent(tracesDataset)) {
                     logger.warning(EnvironmentConfiguration.getErrorMessage("dataset",
                         EnvironmentConfiguration.HONEYCOMB_DATASET));
                 }
@@ -410,7 +410,7 @@ public final class OpenTelemetryConfiguration {
                 headers.entrySet().forEach(entry -> builder.addHeader(entry.getKey(), entry.getValue()));
 
                 // if legacy key and missing dataset, warn on missing dataset
-                if (isLegacyKey(tracesApiKey) && !isPresent(tracesDataset)) {
+                if (isClassicKey(tracesApiKey) && !isPresent(tracesDataset)) {
                     logger.warning(EnvironmentConfiguration.getErrorMessage("dataset",
                         EnvironmentConfiguration.HONEYCOMB_DATASET));
                 }


### PR DESCRIPTION
## Which problem is this PR solving?

We've released Ingest Keys, but need to update the key detection logic to allow Ingest Keys to be used to send data to Classic environments.

## Short description of the changes
- updates the Legacy (Classic) API Key detection logic to understand the shape of a Classic Ingest Key
- Adds a new parameterized test with more detailed test cases
- Renames `isLegacyKey` with `isClassicKey`
- bonus: updated the circleCI image for smoke tests to `ubuntu-2204:2024.01.1` since the one we were using [is deprecated](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177)

## How to verify that this has the expected result

It should be possible to use [an ingest key](https://docs.honeycomb.io/working-with-your-data/settings/api-keys/#ingest-keys-1) pointed to a classic environment after this change. Please note that the ability to create ingest keys in classic environments isn't yet publicly available (since we need to update this library and others to understand classic ingest keys).
