### PR TITLE
rel: prep release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # honeycomb-opentelemetry-java changelog
 
+## [1.6.0] - 2024-03-06
+
+### Enhancements
+
+- feat: add support for classic ingest keys (#448) | [@cewkrupa](https://github.com/cewkrupa)
+
+### Maintenance
+- maint: update codeowners to pipeline-team (#446) | [@JamieDanielson](https://github.com/JamieDanielson)
+- maint: update codeowners to pipeline (#445) | [@JamieDanielson](https://github.com/JamieDanielson)
+
 ## [1.5.2] - 2023-06-21
 
 ### Maintenance

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ allprojects {
     def tag = System.getenv("CIRCLE_TAG")
     if (tag != null && tag.startsWith("v")) {
         // circle tag means we're publishing a release version
-        project.version = "1.5.2"
+        project.version = "1.6.0"
     } else {
-        project.version = "1.5.3-SNAPSHOT"
+        project.version = "1.6.1-SNAPSHOT"
     }
 }
 

--- a/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/DistroMetadata.java
@@ -18,7 +18,7 @@ public class DistroMetadata {
      * with the version number and read it, but that isn't possible from the
      * Java agent.
      */
-    public static final String VERSION_VALUE = "1.5.2";
+    public static final String VERSION_VALUE = "1.6.0";
     public static final String VARIANT_FIELD = "honeycomb.distro.variant";
     public static final String VARIANT_AGENT = "agent";
     public static final String VARIANT_SDK = "sdk";

--- a/licenses/licenses.md
+++ b/licenses/licenses.md
@@ -1,7 +1,7 @@
 
 #agent
 ##Dependency License Report
-_2023-06-21 10:50:10 EDT_
+_2024-03-06 11:27:05 EST_
 ## The Apache License, Version 2.0
 
 **1** **Group:** `io.opentelemetry.javaagent` **Name:** `opentelemetry-javaagent` **Version:** `1.27.0` 


### PR DESCRIPTION
## Which problem is this PR solving?

- release prep for v1.6.0

## Short description of the changes

- update version in root build.gradle to 1.6.0
- update changelog for v1.6.0

A [docs PR](https://github.com/honeycombio/docs/pull/2094) has been prepped with the new release version, to be merged once this release is out / docs is unfrozen.

