### PR TITLE
maint: add labels to release.yml for auto-generated grouping

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,6 +18,8 @@ changelog:
     - title: 🛠 Maintenance
       labels:
         - "type: maintenance"
+        - "type: dependencies"
+        - "type: documentation"
     - title: 🤷 Other Changes
       labels:
         - "*"


### PR DESCRIPTION
## Which problem is this PR solving?

- auto-generated release notes should just automatically include dependencies and docs in maintenance section

## Short description of the changes

- update `release.yml` that gets used for generating release notes to include labels of `type: dependencies` and `type: documentation`
