### PR TITLE
feat: return an OpenTelemetrySdk from the builder

### DIFF
--- a/examples/spring-sdk/src/main/java/io/honeycomb/examples/springbootsdk/Application.java
+++ b/examples/spring-sdk/src/main/java/io/honeycomb/examples/springbootsdk/Application.java
@@ -2,7 +2,7 @@ package io.honeycomb.examples.springbootsdk;
 
 import io.honeycomb.opentelemetry.OpenTelemetryConfiguration;
 import io.honeycomb.opentelemetry.sdk.trace.spanprocessors.BaggageSpanProcessor;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Bean;
 @SpringBootApplication
 public class Application {
     @Bean
-    public OpenTelemetry honeycomb() {
+    public OpenTelemetrySdk honeycomb() {
         return OpenTelemetryConfiguration.builder()
             .addSpanProcessor(new BaggageSpanProcessor())
             .setApiKey(System.getenv("HONEYCOMB_API_KEY"))

--- a/examples/spring-sdk/src/main/java/io/honeycomb/examples/springbootsdk/HelloController.java
+++ b/examples/spring-sdk/src/main/java/io/honeycomb/examples/springbootsdk/HelloController.java
@@ -5,16 +5,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 
 @RestController
 public class HelloController {
     private static final String importantInfo = "Important Information";
 
     @Autowired
-    private OpenTelemetry openTelemetry;
+    private OpenTelemetrySdk openTelemetry;
 
     @GetMapping("/")
     public String index() {

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -275,24 +275,24 @@ public final class OpenTelemetryConfiguration {
         }
 
         /**
-         * Returns a new {@link OpenTelemetry} built with the configuration of this {@link
+         * Returns a new {@link OpenTelemetrySdk} built with the configuration of this {@link
          * Builder} and registers it as the global {@link
          * io.opentelemetry.api.OpenTelemetry}. An exception will be thrown if this method is attempted to
          * be called multiple times in the lifecycle of an application - ensure you have only one SDK for
          * use as the global instance. If you need to configure multiple SDKs for tests, use {@link
          * GlobalOpenTelemetry#resetForTest()} between them.
          *
-         * @return {@link OpenTelemetry} instance
+         * @return {@link OpenTelemetrySdk} instance
          * @see GlobalOpenTelemetry
          */
-        public OpenTelemetry buildAndRegisterGlobal() {
-            OpenTelemetry sdk = build();
+        public OpenTelemetrySdk buildAndRegisterGlobal() {
+            OpenTelemetrySdk sdk = build();
             GlobalOpenTelemetry.set(sdk);
             return sdk;
         }
 
         /**
-         * Returns a new {@link OpenTelemetry} built with the configuration of this {@link
+         * Returns a new {@link OpenTelemetrySdk} built with the configuration of this {@link
          * Builder}. This SDK is not registered as the global {@link
          * io.opentelemetry.api.OpenTelemetry}. It is recommended that you register one SDK using {@link
          * Builder#buildAndRegisterGlobal()} for use by instrumentation that requires
@@ -302,10 +302,10 @@ public final class OpenTelemetryConfiguration {
          * {@link SdkTracerProvider} with a {@link BatchSpanProcessor} that has an
          * {@link OtlpGrpcSpanExporter} configured.</p>
          *
-         * @return {@link OpenTelemetry} instance
+         * @return {@link OpenTelemetrySdk} instance
          * @see GlobalOpenTelemetry
          */
-        public OpenTelemetry build() {
+        public OpenTelemetrySdk build() {
             Preconditions.checkNotNull(sampler, "sampler must be non-null");
 
             Logger logger = Logger.getLogger(OpenTelemetryConfiguration.class.getName());

--- a/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
+++ b/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java
@@ -4,7 +4,6 @@ import com.google.common.base.Preconditions;
 import io.honeycomb.opentelemetry.sdk.trace.samplers.DeterministicTraceSampler;
 import io.honeycomb.opentelemetry.sdk.trace.spanprocessors.BaggageSpanProcessor;
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;


### PR DESCRIPTION
A nice-to-have that I've wanted from working with this SDK on personal projects.

Otel, for very very good reason, periodically batches telemetry before sending it upstream. When I'm writing short-lived command line apps, I need to `.shutdown()` the otel sdk before exiting the process.

But `shutdown` is only a method on the `OpenTelemetrySdk`, not `OpenTelemetry`, so I have to (gasp) cast it to the right type because I looked at the source code and could see that we return one of those. 

I don't know enough Java to know if this is a big no-no, but as a user this would be appreciated ❤️ 