### PR TITLE
maint: bump otel to 1.35/1.33.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry         : "1.27.0",
-                opentelemetryJavaagent: "1.27.0",
+                opentelemetry         : "1.35.0",
+                opentelemetryJavaagent: "1.33.1",
                 bytebuddy             : "1.10.18",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"

--- a/sdk/src/test/java/io/honeycomb/opentelemetry/OpenTelemetryConfigurationTest.java
+++ b/sdk/src/test/java/io/honeycomb/opentelemetry/OpenTelemetryConfigurationTest.java
@@ -77,7 +77,7 @@ public class OpenTelemetryConfigurationTest {
             Assertions.assertInstanceOf(BaggageSpanProcessor.class, processors.get(0));
             Assertions.assertInstanceOf(BatchSpanProcessor.class, processors.get(1));
             SpanProcessor processor = processors.get(1);
-            Assertions.assertTrue(processor.toString().contains("spanExporter=io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter"));
+            Assertions.assertTrue(processor.toString().contains("spanExporter=OtlpGrpcSpanExporter"));
         } catch (Exception e) {
             Assertions.fail(e);
         }
@@ -109,7 +109,7 @@ public class OpenTelemetryConfigurationTest {
             // verify configured span processors
             Assertions.assertInstanceOf(BatchSpanProcessor.class, processors.get(1));
             SpanProcessor processor = processors.get(1);
-            Assertions.assertTrue(processor.toString().contains("spanExporter=io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter"));
+            Assertions.assertTrue(processor.toString().contains("spanExporter=OtlpHttpSpanExporter"));
         } catch (Exception e) {
             Assertions.fail(e);
         }


### PR DESCRIPTION
## Which problem is this PR solving?

- outdated otel dependencies

## Short description of the changes

- bump opentelemetry to [1.35](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.35.0)
- bump opentelemetry agent to [1.33.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.33.1)
- update test for new spanExporter name (upstream dropped fqdn in changes to exporter that makes it easier to debug configuration)

