### PR TITLE
feat: Add local exporter

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,6 +7,7 @@ def artifactName = "honeycomb-opentelemetry-common"
 description = 'Functionality shared across components of the Honeycomb OpenTelemetry distribution.'
 
 dependencies {
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     compileOnly "io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}"
 
     testImplementation "io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:4.11.0'
     testImplementation 'org.mockito:mockito-inline:4.6.1'
     testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'
+    testImplementation 'com.github.gmazzo.okhttp.mock:mock-client:2.0.0'
 }
 
 jar {

--- a/common/src/main/java/io/honeycomb/opentelemetry/sdk/trace/export/LocalExporter.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/sdk/trace/export/LocalExporter.java
@@ -19,11 +19,10 @@ public class LocalExporter implements SpanExporter {
     private String traceUrl = "";
 
     public LocalExporter(String serviceName, String apikey) {
-        OkHttpClient client = new OkHttpClient();
-        LocalExporter(serviceName, apikey, client);
+        this(serviceName, apikey, new OkHttpClient());
     }
 
-    private LocalExporter(Stirng serviceName, String apikey, OkHttpClient client) {
+    private LocalExporter(String serviceName, String apikey, OkHttpClient client) {
         if (!serviceName.isEmpty() || apikey.isEmpty()) {
             System.out.println("WARN: disabling local visualisations - must have both service name and API key configured.");
         }

--- a/common/src/main/java/io/honeycomb/opentelemetry/sdk/trace/export/LocalExporter.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/sdk/trace/export/LocalExporter.java
@@ -1,0 +1,78 @@
+package io.honeycomb.opentelemetry.sdk.trace.export;
+
+import static io.honeycomb.opentelemetry.EnvironmentConfiguration.isClassicKey;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class LocalExporter implements SpanExporter {
+
+    private String traceUrl = "";
+
+    public LocalExporter(String serviceName, String apikey) {
+        if (!serviceName.isEmpty() || apikey.isEmpty()) {
+            System.out.println("WARN: disabling local visualisations - must have both service name and API key configured.");
+        }
+
+        OkHttpClient client = new OkHttpClient();
+        Request request = new Request.Builder()
+            .url("https://api.honeycomb.io/1/auth")
+            .addHeader("X-Honeycomb-Team", apikey)
+            .addHeader("Content-Type", "application/json")
+            .build();
+
+        try {
+            Response response = client.newCall(request).execute();
+            if (response.code() == 200) {
+                String body = response.body().string();
+                String team = body.split("\"team\":")[1].split(",")[0];
+                String environment = body.split("\"environment\":")[1].split(",")[0];
+                traceUrl = buildTraceUrl(apikey, serviceName, team, environment);
+            } else {
+                System.out.println("WARN: failed to extract team from Honeycomb auth response");
+            }
+        } catch (IOException e) {
+            System.out.println("WARN: failed to extract team from Honeycomb auth response");
+        }
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> spans) {
+        if (!traceUrl.isEmpty()) {
+            spans.forEach((span) -> {
+                if (span.getParentSpanContext() == SpanContext.getInvalid()) {
+                    System.out.println(String.format("Honeycomb link: %s=%s", traceUrl, span.getTraceId()));
+                }
+            });
+        }
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    private String buildTraceUrl(String apikey, String serviceName, String team, String environment) {
+        StringBuilder url = new StringBuilder("https://ui.honeycomb.io/").append(team);
+        if (!isClassicKey(apikey)) {
+            url.append("/environments/").append(environment);
+        }
+        url.append(team).append("/datasets/").append(serviceName).append("/traces?trace_id");
+        return url.toString();
+    }
+}

--- a/common/src/main/java/io/honeycomb/opentelemetry/sdk/trace/export/LocalExporter.java
+++ b/common/src/main/java/io/honeycomb/opentelemetry/sdk/trace/export/LocalExporter.java
@@ -19,11 +19,15 @@ public class LocalExporter implements SpanExporter {
     private String traceUrl = "";
 
     public LocalExporter(String serviceName, String apikey) {
+        OkHttpClient client = new OkHttpClient();
+        LocalExporter(serviceName, apikey, client);
+    }
+
+    private LocalExporter(Stirng serviceName, String apikey, OkHttpClient client) {
         if (!serviceName.isEmpty() || apikey.isEmpty()) {
             System.out.println("WARN: disabling local visualisations - must have both service name and API key configured.");
         }
 
-        OkHttpClient client = new OkHttpClient();
         Request request = new Request.Builder()
             .url("https://api.honeycomb.io/1/auth")
             .addHeader("X-Honeycomb-Team", apikey)

--- a/common/src/test/java/io/honeycomb/opentelemetry/sdk/trace/export/LocalExportTest.java
+++ b/common/src/test/java/io/honeycomb/opentelemetry/sdk/trace/export/LocalExportTest.java
@@ -1,0 +1,58 @@
+package io.honeycomb.opentelemetry.sdk.trace.export;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+
+import okhttp3.*;
+import okhttp3.mock.*;
+
+@ExtendWith(MockitoExtension.class)
+public class LocalExportTest {
+
+    @Test
+    public void testLocalExport(@Mock SpanData span) {
+        // create the mock interceptor that will return the team and environment from the auth endpoint
+        MockInterceptor interceptor = new MockInterceptor(Behavior.UNORDERED);
+        interceptor.addRule()
+            .get("https://api.honeycomb.io/1/auth")
+            .respond("{\"team\":\"team\",\"environment\":\"env\"}");
+
+        // create the client using the mock interceptor
+        OkHttpClient client = new OkHttpClient.Builder()
+            .addInterceptor(interceptor)
+            .build();
+
+        // mock the span to return an invalid parent context and a span id
+        Mockito.when(span.getParentSpanContext()).thenReturn(SpanContext.getInvalid());
+        Mockito.when(span.getTraceId()).thenReturn("my-span-id");
+
+        // set up the output stream to capture the output
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        // create the exporter
+        LocalExporter exporter = new LocalExporter("service", "apikey", client);
+
+        // export the span and check the result
+        CompletableResultCode result = exporter.export(Arrays.asList(span));
+        assertTrue(result.isSuccess());
+
+        // check the url was logged to the console
+        String output = out.toString();
+        assertTrue(output.contains("https://ui.honeycomb.io/trace-view/team/env/service?trace_id=" + span.getTraceId()));
+    }
+}

--- a/examples/spring-sdk/src/main/java/io/honeycomb/examples/springbootsdk/Application.java
+++ b/examples/spring-sdk/src/main/java/io/honeycomb/examples/springbootsdk/Application.java
@@ -1,6 +1,7 @@
 package io.honeycomb.examples.springbootsdk;
 
 import io.honeycomb.opentelemetry.OpenTelemetryConfiguration;
+import io.honeycomb.opentelemetry.sdk.trace.samplers.DeterministicTraceSampler;
 import io.honeycomb.opentelemetry.sdk.trace.spanprocessors.BaggageSpanProcessor;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 
@@ -13,7 +14,10 @@ public class Application {
     @Bean
     public OpenTelemetrySdk honeycomb() {
         return OpenTelemetryConfiguration.builder()
+            // add baggage span processor that copies baggage attributes to new spans
             .addSpanProcessor(new BaggageSpanProcessor())
+            // set deterministic trace sampler with sample rate of 1/1 (100%)
+            .setSampler(new DeterministicTraceSampler(1))
             .setApiKey(System.getenv("HONEYCOMB_API_KEY"))
             .setDataset(System.getenv("HONEYCOMB_DATASET"))
             .setServiceName(System.getenv("SERVICE_NAME"))

--- a/examples/spring-sdk/src/main/java/io/honeycomb/examples/springbootsdk/Application.java
+++ b/examples/spring-sdk/src/main/java/io/honeycomb/examples/springbootsdk/Application.java
@@ -1,7 +1,6 @@
 package io.honeycomb.examples.springbootsdk;
 
 import io.honeycomb.opentelemetry.OpenTelemetryConfiguration;
-import io.honeycomb.opentelemetry.sdk.trace.samplers.DeterministicTraceSampler;
 import io.honeycomb.opentelemetry.sdk.trace.spanprocessors.BaggageSpanProcessor;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 
@@ -14,10 +13,7 @@ public class Application {
     @Bean
     public OpenTelemetrySdk honeycomb() {
         return OpenTelemetryConfiguration.builder()
-            // add baggage span processor that copies baggage attributes to new spans
             .addSpanProcessor(new BaggageSpanProcessor())
-            // set deterministic trace sampler with sample rate of 1/1 (100%)
-            .setSampler(new DeterministicTraceSampler(1))
             .setApiKey(System.getenv("HONEYCOMB_API_KEY"))
             .setDataset(System.getenv("HONEYCOMB_DATASET"))
             .setServiceName(System.getenv("SERVICE_NAME"))


### PR DESCRIPTION
## Which problem is this PR solving?

Adds the local exporter that prints out Honeycomb URLs to view a completed trace.

## Short description of the changes
- Adds local exporter
- Update example to show how to configure the components

TODO:
- [ ] Add tests for exporter to verify
  - Mock HTTP request for auth endpoint
  - `buildTraceUrl` constructs the expected URL
- [ ] Automatically add the local exporter when `HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS` is true or SDK options enable it - see [Node distro example](https://github.com/honeycombio/honeycomb-opentelemetry-node/blob/25937435d4cdb73ad9bde0983e12716b8ff4ac22/src/baggage-span-processor.ts#L34)
- [ ] Add example to spring-sdk example to show how to configure